### PR TITLE
Fix Landscape complaint "Method has no argument"

### DIFF
--- a/behave_django/runner.py
+++ b/behave_django/runner.py
@@ -22,8 +22,8 @@ class ExistingDatabaseTestRunner(DiscoverRunner, BehaveHooksMixin):
     """
     testcase_class = ExistingDatabaseTestCase
 
-    def setup_databases(*args, **kwargs):
+    def setup_databases(self, **kwargs):
         pass
 
-    def teardown_databases(*args, **kwargs):
+    def teardown_databases(self, old_config, **kwargs):
         pass


### PR DESCRIPTION
Adds the missing `self` argument to the two methods of the class we're overriding. This makes the signature of the two methods match the one of Django:

- [Django 1.10](https://github.com/django/django/blob/1.10/django/test/runner.py#L496)
- [Django 1.9](https://github.com/django/django/blob/1.9/django/test/runner.py#L479)
- [Django 1.8](https://github.com/django/django/blob/1.8/django/test/runner.py#L163)
- [Django 1.7](https://github.com/django/django/blob/1.7/django/test/runner.py#L108)

Amazing that we didn't see this before! Even though Landscape was complaining.