### PR TITLE
Fix Landscape complaint "Method has no argument" (testcase)

### DIFF
--- a/behave_django/testcase.py
+++ b/behave_django/testcase.py
@@ -8,7 +8,7 @@ class BehaviorDrivenTestCase(StaticLiveServerTestCase):
     This test case prevents the regular tests from running.
     """
 
-    def runTest(*args, **kwargs):
+    def runTest(self):
         pass
 
 


### PR DESCRIPTION
This PR fixes another missing `self` argument, a code smell detected by Landscape (prospector), this time in the `BehaviorDrivenTestCase` class.

The `runTest` method comes from Python's `unittest.TestCase`, and according to the [Python documentation](https://docs.python.org/3/library/unittest.html#test-cases) and the Python 3.4 source code it's called with no arguments always. Hence the change should be alright.