### PR TITLE
Improve parser

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ master
 
 - Behave's short form arguments are now accepted (e.g. :code:`-i` for :code:`--include`)
 - Added :code:`--keepdb` short form argument, `-k`
+- Prefix conflicting command line options with :code:`--behave`
 
 **Bugfixes**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,18 @@
 Release History
 ---------------
 
+master
+++++++
+
+**Features and Improvements**
+
+* Behave's short form arguments are now accepted (e.g. :code:`-i` for :code:`--include`)
+* Added :code:`--keepdb` short form argument, `-k`
+
+**Bugfixes**
+* Fixed specifying paths didn't work
+
+
 0.4.0 (2016-08-23)
 ++++++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,11 +6,12 @@ master
 
 **Features and Improvements**
 
-* Behave's short form arguments are now accepted (e.g. :code:`-i` for :code:`--include`)
-* Added :code:`--keepdb` short form argument, `-k`
+- Behave's short form arguments are now accepted (e.g. :code:`-i` for :code:`--include`)
+- Added :code:`--keepdb` short form argument, `-k`
 
 **Bugfixes**
-* Fixed specifying paths didn't work
+
+- Fixed specifying paths didn't work
 
 
 0.4.0 (2016-08-23)

--- a/behave_django/management/commands/behave.py
+++ b/behave_django/management/commands/behave.py
@@ -57,22 +57,16 @@ def add_behave_arguments(parser):  # noqa
             continue
 
         # Build option strings
-        # Conflicting option strings get prefixed with `--behave`
         option_strings = []
         for option in fixed:
+            # Prefix conflicting option strings with `--behave`
             if option in conflicts:
-                if option.startswith('--'):
-                    option = '--behave-' + option[2:]
-                else:
-                    option = '--behave-' + option[1:]
+                prefix = '--' if option.startswith('--') else '-'
+                option = option.replace(prefix, '--behave-', maxreplace=1)
 
             option_strings.append(option)
 
-        # type isn't a valid keyword for make_option
-        if hasattr(keywords.get('type'), '__call__'):
-            del keywords['type']
-
-        # config_help isn't a valid keyword for make_option
+        # config_help isn't a valid keyword for add_argument
         if 'config_help' in keywords:
             keywords['help'] = keywords['config_help']
             del keywords['config_help']
@@ -133,15 +127,13 @@ class Command(BaseCommand):
 
         behave_args = []
         for option in unknown:
-            if '--behave' in option:
-                if len(option) == len('--behave-x'):
-                    # Strip behave prefix from short options
-                    behave_args.append(option.replace('--behave', ''))
-                else:
-                    # Strip behave prefix from long options
-                    behave_args.append(option.replace('behave-', ''))
-            else:
-                behave_args.append(option)
+            # Remove behave prefix
+            if option.startswith('--behave-'):
+                option = option.replace('--behave-', '')
+                prefix = '-' if len(option) == 1 else '--'
+                option = prefix + option
+
+            behave_args.append(option)
 
         return behave_args
 

--- a/behave_django/management/commands/behave.py
+++ b/behave_django/management/commands/behave.py
@@ -81,11 +81,9 @@ class Command(BaseCommand):
         """
         Add behave's and our command line arguments to the command
         """
-        usage = "%(prog)s [options] [ [DIR|FILE|FILE:LINE] ]+"
-        description = """\
+        parser.usage = "%(prog)s [options] [ [DIR|FILE|FILE:LINE] ]+"
+        parser.description = """\
         Run a number of feature tests with behave."""
-        parser.usage = usage
-        parser.description = description
 
         add_command_arguments(parser)
         add_behave_arguments(parser)

--- a/behave_django/management/commands/behave.py
+++ b/behave_django/management/commands/behave.py
@@ -129,7 +129,7 @@ class Command(BaseCommand):
         for option in unknown:
             # Remove behave prefix
             if option.startswith('--behave-'):
-                option = option.replace('--behave-', '')
+                option = option.replace('--behave-', '', 1)
                 prefix = '-' if len(option) == 1 else '--'
                 option = prefix + option
 

--- a/behave_django/management/commands/behave.py
+++ b/behave_django/management/commands/behave.py
@@ -62,7 +62,7 @@ def add_behave_arguments(parser):  # noqa
             # Prefix conflicting option strings with `--behave`
             if option in conflicts:
                 prefix = '--' if option.startswith('--') else '-'
-                option = option.replace(prefix, '--behave-', maxreplace=1)
+                option = option.replace(prefix, '--behave-', 1)
 
             option_strings.append(option)
 

--- a/behave_django/management/commands/behave.py
+++ b/behave_django/management/commands/behave.py
@@ -56,17 +56,17 @@ def add_behave_arguments(parser):  # noqa
         if not fixed:
             continue
 
-        # Build option strings, not including conflicting option strings
+        # Build option strings
+        # Conflicting option strings get prefixed with `--behave`
         option_strings = []
         for option in fixed:
             if option in conflicts:
-                continue
+                if option.startswith('--'):
+                    option = '--behave-' + option[2:]
+                else:
+                    option = '--behave-' + option[1:]
 
             option_strings.append(option)
-
-        # Conflicting option strings are omitted
-        if not option_strings:
-            continue
 
         # type isn't a valid keyword for make_option
         if hasattr(keywords.get('type'), '__call__'):
@@ -130,7 +130,20 @@ class Command(BaseCommand):
         """
         parser = BehaveArgsHelper().create_parser('manage.py', 'behave')
         args, unknown = parser.parse_known_args(argv[2:])
-        return unknown
+
+        behave_args = []
+        for option in unknown:
+            if '--behave' in option:
+                if len(option) == len('--behave-x'):
+                    # Strip behave prefix from short options
+                    behave_args.append(option.replace('--behave', ''))
+                else:
+                    # Strip behave prefix from long options
+                    behave_args.append(option.replace('behave-', ''))
+            else:
+                behave_args.append(option)
+
+        return behave_args
 
 
 class BehaveArgsHelper(Command):

--- a/behave_django/management/commands/behave.py
+++ b/behave_django/management/commands/behave.py
@@ -39,7 +39,7 @@ def add_behave_arguments(parser):  # noqa
         '--version',
         '-c',
         '-k',
-        '-v'
+        '-v',
     ]
 
     parser.add_argument(
@@ -64,8 +64,8 @@ def add_behave_arguments(parser):  # noqa
 
             option_strings.append(option)
 
-        # No use in adding an option if it doesn't have an option string
-        if len(option_strings) == 0:
+        # Conflicting option strings are omitted
+        if not option_strings:
             continue
 
         # type isn't a valid keyword for make_option

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ paths = features/
 show_skipped = no
 
 [flake8]
-exclude = docs,.cache,.tox,*.egg-info
+exclude = docs,.cache,.tox,*.egg-info,.ropeproject
 
-[pytest]
+[tool:pytest]
 testpaths = tests/

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,8 @@ class TestCommandLine(DjangoSetupMixin):
         assert exit_status == 0
         assert (
             os.linesep + '  --use-existing-database' + os.linesep) in output
+        assert (
+            os.linesep + '  -k, --keepdb') in output
 
     def test_should_accept_behave_arguments(self):
         from behave_django.management.commands.behave import Command
@@ -31,10 +33,13 @@ class TestCommandLine(DjangoSetupMixin):
             argv=['manage.py', 'behave',
                   '--format', 'progress',
                   '--settings', 'test_project.settings',
+                  '-i', 'some-pattern',
                   'features/running-tests.feature'])
 
         assert '--format' in args
         assert 'progress' in args
+        assert '-i' in args
+        assert 'some-pattern' in args
 
     def test_should_not_include_non_behave_arguments(self):
         from behave_django.management.commands.behave import Command
@@ -66,6 +71,11 @@ class TestCommandLine(DjangoSetupMixin):
             argv=['manage.py', 'behave'])
 
         assert args == []
+
+    def test_positional_args_should_work(self):
+        exit_status, output = run_silently(
+            'python manage.py behave features/running-tests.feature')
+        assert exit_status == 0
 
     def test_command_import_dont_patch_behave_options(self):
         # We reload the tested imports because they

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,3 +91,11 @@ class TestCommandLine(DjangoSetupMixin):
         reload(behave_django.management.commands.behave)
 
         assert behave.configuration.options == behave_options_backup
+
+    def test_conflicting_options_should_get_prefixed(self):
+        from behave_django.management.commands.behave import Command
+        command = Command()
+        args = command.get_behave_args(
+            argv=['manage.py', 'behave', '--behave-k', '--behave-version'])
+
+        assert args == ['-k', '--version']


### PR DESCRIPTION
Improve parser

* Add behave short options to parser

e.g. -d for --dry-run, -e for --exclude

* Fix specifying paths bug

Before this PR, specifying a path will not work since our parser didn't have an
option for positional argument. This PR adds a `paths` argument.

* Customize parser's usage and description text to match behave's

The default usage and description was very messy. This PR updates them to be
like behave's.

* Add short option (-k) to --keepdb argument