### PR TITLE
Add missing Django 1.8 + Python 3.5 combination to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:  # $ tox -l | sort | xargs -I _ echo '  - TOXENV=_'
   - TOXENV=py34-django18
   - TOXENV=py34-django19
   - TOXENV=py34-django110
+  - TOXENV=py35-django18
   - TOXENV=py35-django19
   - TOXENV=py35-django110
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 envlist =
     flake8
-    py{27,33,34}-django18
+    py{27,33,34,35}-django18
     py{27,34,35}-django19
     py{27,34,35}-django110
     docs


### PR DESCRIPTION
For some reason Python 3.5 was not covered for testing against Django 1.8.

The changes in this PR add py35-django18 to the Tox configuration and the test matrix on Travis.