### PR TITLE
Configure Read The Docs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -59,7 +59,7 @@ Release History
 **Features and Improvements**
 
 - Integration with :code:`behave` is now done via monkey patching. Including the :code:`environment.before_scenario()` and :code:`environment.after_scenario()` function calls in your :code:`environment.py` file is no longer needed.
-- A new CLI option, :code:`--use-existing-database`, has been added. See the `usage docs <https://pythonhosted.org/behave-django/usage.html#behave-command-line-options>`__.
+- A new CLI option, :code:`--use-existing-database`, has been added. See the `usage docs <https://behave-django.readthedocs.io/en/latest/usage.html#command-line-options>`__.
 
 **Bugfixes**
 

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ that release for Django 1.7.x and below.  There is no technical disadvantage.
 Documentation
 -------------
 
--  Documentation is available from `pythonhosted.org/behave-django`_
+-  Documentation is available from `behave-django.readthedocs.io`_
 -  Read more about ``behave`` at `behave.readthedocs.io`_
 
 .. contribute-marker
@@ -53,9 +53,9 @@ Please, read the `contributing guide`_ in the docs.
 
 .. _version 0.3.0: https://pypi.python.org/pypi/behave-django/0.3.0
 .. _behave: https://pypi.python.org/pypi/behave
-.. _pythonhosted.org/behave-django: https://pythonhosted.org/behave-django/
+.. _behave-django.readthedocs.io: https://behave-django.readthedocs.io/en/latest/
 .. _behave.readthedocs.io: https://behave.readthedocs.io/en/latest/django.html
-.. _contributing guide: https://pythonhosted.org/behave-django/contribute.html
+.. _contributing guide: https://behave-django.readthedocs.io/en/latest/contribute.html
 .. |latest-version| image:: https://img.shields.io/pypi/v/behave-django.svg
     :target: https://pypi.python.org/pypi/behave-django/
     :alt: Latest version

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'behave-django'
-copyright = u'2016, Mitchel Cabuloy'
+copyright = u'2017, Mitchel Cabuloy'
 author = u'Mitchel Cabuloy'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
I've set up the project to work with Read The Docs and updated the links from pythonhosted to readthedocs in our repo. I also updated the theme to use the RTD theme. [Here's a preview.](https://behave-django.readthedocs.io/en/readthedocs/)

I'll also probably upload a placeholder redirect page to the old pythonhosted docs site, or an actual redirect if that's possible.

Fixes #11 