### PR TITLE
Simple tests support

### DIFF
--- a/behave_django/environment.py
+++ b/behave_django/environment.py
@@ -1,22 +1,17 @@
 from behave.runner import ModelRunner, Context
 from django.core.management import call_command
 from django.shortcuts import resolve_url
-from django.core.exceptions import ImproperlyConfigured
 
 
 class PatchedContext(Context):
 
     @property
     def base_url(self):
-
-        if hasattr(self.test, 'live_server_url'):
-            return self.test.live_server_url
-
-        raise ImproperlyConfigured(
+        assert hasattr(self.test, 'live_server_url'), (
             'Web browser automation is not available.'
             ' This scenario step can not be run'
-            ' with the --simple or -S flag.'
-        )
+            ' with the --simple or -S flag.')
+        return self.test.live_server_url
 
     def get_url(self, to=None, *args, **kwargs):
         return self.base_url + (

--- a/behave_django/management/commands/behave.py
+++ b/behave_django/management/commands/behave.py
@@ -7,7 +7,8 @@ from django.core.management.base import BaseCommand
 
 from behave_django.environment import monkey_patch_behave
 from behave_django.runner import (BehaviorDrivenTestRunner,
-                                  ExistingDatabaseTestRunner)
+                                  ExistingDatabaseTestRunner,
+                                  SimpleTestRunner)
 
 
 def add_command_arguments(parser):
@@ -26,6 +27,13 @@ def add_command_arguments(parser):
         default=False,
         help="Preserves the test DB between runs.",
     )
+    parser.add_argument(
+        '-S', '--simple',
+        action='store_true',
+        default=False,
+        help="Use simple test runner that supports Django's"
+        " testing client only (no web browser automation)"
+    )
 
 
 def add_behave_arguments(parser):  # noqa
@@ -40,6 +48,8 @@ def add_behave_arguments(parser):  # noqa
         '-c',
         '-k',
         '-v',
+        '-S',
+        '--simple',
     ]
 
     parser.add_argument(
@@ -93,6 +103,8 @@ class Command(BaseCommand):
         # Configure django environment
         if options['dry_run'] or options['use_existing_database']:
             django_test_runner = ExistingDatabaseTestRunner()
+        elif options['simple']:
+            django_test_runner = SimpleTestRunner()
         else:
             django_test_runner = BehaviorDrivenTestRunner()
 

--- a/behave_django/management/commands/behave.py
+++ b/behave_django/management/commands/behave.py
@@ -100,6 +100,13 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
 
+        # Check the flags
+        if options['use_existing_database'] and options['simple']:
+            self.stderr.write(self.style.WARNING(
+                '--simple flag has no effect'
+                ' together with --use-existing-database'
+            ))
+
         # Configure django environment
         if options['dry_run'] or options['use_existing_database']:
             django_test_runner = ExistingDatabaseTestRunner()

--- a/behave_django/runner.py
+++ b/behave_django/runner.py
@@ -2,7 +2,8 @@ from django.test.runner import DiscoverRunner
 
 from behave_django.environment import BehaveHooksMixin
 from behave_django.testcase import (BehaviorDrivenTestCase,
-                                    ExistingDatabaseTestCase)
+                                    ExistingDatabaseTestCase,
+                                    DjangoSimpleTestCase)
 
 
 class BehaviorDrivenTestRunner(DiscoverRunner, BehaveHooksMixin):
@@ -27,3 +28,11 @@ class ExistingDatabaseTestRunner(DiscoverRunner, BehaveHooksMixin):
 
     def teardown_databases(self, old_config, **kwargs):
         pass
+
+
+class SimpleTestRunner(DiscoverRunner, BehaveHooksMixin):
+    """
+    Test runner that uses DjangoSimpleTestCase with atomic
+    transaction management and no support of web browser automation.
+    """
+    testcase_class = DjangoSimpleTestCase

--- a/behave_django/testcase.py
+++ b/behave_django/testcase.py
@@ -1,4 +1,5 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.test.testcases import TestCase
 
 
 class BehaviorDrivenTestCase(StaticLiveServerTestCase):
@@ -23,4 +24,23 @@ class ExistingDatabaseTestCase(BehaviorDrivenTestCase):
         pass
 
     def _fixture_teardown(self):
+        pass
+
+
+class DjangoSimpleTestCase(TestCase):
+    """
+    Test case attached to the context during behave execution
+
+    This test case uses `transaction.atomic()` to achieve test isolation
+    instead of flushing the entire database. As a result, tests run much
+    quicker and have no issues with altered DB state after all tests ran
+    when `--keepdb` is used.
+
+    As a side effect, this test case does not support web browser automation.
+    Use Django's testing client instead to test requests and responses.
+
+    Also, it prevents the regular tests from running.
+    """
+
+    def runTest(self):
         pass

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -17,13 +17,13 @@ Install the dev dependencies
     $ pip install -r requirements-dev.txt
 
 Make sure the tests pass.  The ``@failing`` tag is used for tests that are
-supposed to fail. The ``@no-simple`` tag is used for tests that can't run
+supposed to fail. The ``@requires-live-http`` tag is used for tests that can't run
 with ``--simple`` flag.
 
 .. code:: bash
 
     $ python manage.py behave --tags=~@failing  # skip failing tests
-    $ python manage.py behave --simple --tags=~@failing --tags=~@no-simple
+    $ python manage.py behave --simple --tags=~@failing --tags=~@requires-live-http
     $ py.test
 
 Start your topic branch

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -17,11 +17,13 @@ Install the dev dependencies
     $ pip install -r requirements-dev.txt
 
 Make sure the tests pass.  The ``@failing`` tag is used for tests that are
-supposed to fail.
+supposed to fail. The ``@no-simple`` tag is used for tests that can't run
+with ``--simple`` flag.
 
 .. code:: bash
 
     $ python manage.py behave --tags=~@failing  # skip failing tests
+    $ python manage.py behave --simple --tags=~@failing --tags=~@no-simple
     $ py.test
 
 Start your topic branch

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -48,6 +48,20 @@ testing client.
         # save response in context for next step
         context.response = context.test.client.get(url)
 
+
+Simple testing
+--------------
+
+If you only use Django's testing client then behave tests can run
+much quicker with the ``--simple`` command line option. In this case
+transaction rollback is used for test automation instead of flushing
+the database after each scenario, just like in Django's standard
+``TestCase``.
+
+No HTTP server is started during the simple testing, so you can't
+use web browser automation. Accessing ``context.base_url``
+or calling ``context.get_url()`` will raise an exception.
+
 unittest + Django assert library
 --------------------------------
 
@@ -161,6 +175,14 @@ to facilitate faster testing by using the existing database instead of
 recreating it each time you run the test. This flag enables
 ``manage.py behave --keepdb`` to take advantage of that feature.
 |keepdb docs|_.
+
+``--simple``
+************
+
+Use Django's simple ``TestCase`` which rolls back the database transaction after
+each scenario instead of flushing the entire database. Tests run much quicker,
+however HTTP server is not started and therefore web browser automation is
+not available.
 
 Behave configuration file
 -------------------------

--- a/features/context-urlhelper.feature
+++ b/features/context-urlhelper.feature
@@ -1,4 +1,4 @@
-@no-simple
+@requires-live-http
 Feature: URL helpers are available in behave's context
     In order to ensure that url helpers are available as documented
     As the Maintainer

--- a/features/context-urlhelper.feature
+++ b/features/context-urlhelper.feature
@@ -1,3 +1,4 @@
+@no-simple
 Feature: URL helpers are available in behave's context
     In order to ensure that url helpers are available as documented
     As the Maintainer

--- a/features/live-test-server.feature
+++ b/features/live-test-server.feature
@@ -1,4 +1,4 @@
-@no-simple
+@requires-live-http
 Feature: Live server
     In order to prove that the live server works
     As the Maintainer

--- a/features/live-test-server.feature
+++ b/features/live-test-server.feature
@@ -1,3 +1,4 @@
+@no-simple
 Feature: Live server
     In order to prove that the live server works
     As the Maintainer

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,8 @@ class TestCommandLine(DjangoSetupMixin):
             os.linesep + '  --use-existing-database' + os.linesep) in output
         assert (
             os.linesep + '  -k, --keepdb') in output
+        assert (
+            os.linesep + '  -S, --simple') in output
 
     def test_should_accept_behave_arguments(self):
         from behave_django.management.commands.behave import Command

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ def run_silently(command):
         command_args, stdout=PIPE, stderr=PIPE, stdin=PIPE)
     stdout, stderr = process.communicate()
     output = (stdout.decode('UTF-8') + os.linesep +
-              stderr.decode('UTF-8')).strip()
+              stderr.decode('UTF-8')).strip() + os.linesep
     return process.returncode, output
 
 
@@ -101,3 +101,15 @@ class TestCommandLine(DjangoSetupMixin):
             argv=['manage.py', 'behave', '--behave-k', '--behave-version'])
 
         assert args == ['-k', '--version']
+
+    def test_simple_and_use_existing_database_flags_raise_a_warning(self):
+        exit_status, output = run_silently(
+            'python manage.py behave'
+            '    --simple --use-existing-database --tags=@skip-all'
+        )
+        assert exit_status == 0
+        assert (
+            os.linesep +
+            '--simple flag has no effect ' +
+            'together with --use-existing-database' +
+            os.linesep) in output

--- a/tests/test_simple_testcase.py
+++ b/tests/test_simple_testcase.py
@@ -1,0 +1,43 @@
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
+
+from .util import DjangoSetupMixin
+from behave_django.runner import SimpleTestRunner
+from behave.runner import Context, Runner
+from django.core.exceptions import ImproperlyConfigured
+from django.test.testcases import TestCase
+import pytest
+
+
+class TestSimpleTestCase(DjangoSetupMixin):
+
+    @mock.patch('behave_django.management.commands.behave.behave_main', return_value=0)  # noqa
+    @mock.patch('behave_django.management.commands.behave.SimpleTestRunner')  # noqa
+    def test_use_simple_test_runner(self,
+                                    mock_simple_test_runner,
+                                    mock_behave_main):
+        self.run_management_command('behave', simple=True)
+        mock_behave_main.assert_called_once_with(args=[])
+        mock_simple_test_runner.assert_called_once_with()
+
+    def test_simple_test_runner_uses_simple_testcase(self):
+        runner = mock.MagicMock()
+        context = Context(runner)
+        SimpleTestRunner().before_scenario(context)
+        assert isinstance(context.test, TestCase)
+
+    def test_simple_testcase_fails_when_accessing_base_url(self):
+        runner = Runner(mock.MagicMock())
+        runner.context = Context(runner)
+        SimpleTestRunner().before_scenario(runner.context)
+        with pytest.raises(ImproperlyConfigured):
+            assert runner.context.base_url == 'should raise an exception!'
+
+    def test_simple_testcase_fails_when_calling_get_url(self):
+        runner = Runner(mock.MagicMock())
+        runner.context = Context(runner)
+        SimpleTestRunner().before_scenario(runner.context)
+        with pytest.raises(ImproperlyConfigured):
+            runner.context.get_url()

--- a/tests/test_simple_testcase.py
+++ b/tests/test_simple_testcase.py
@@ -6,7 +6,6 @@ except ImportError:
 from .util import DjangoSetupMixin
 from behave_django.runner import SimpleTestRunner
 from behave.runner import Context, Runner
-from django.core.exceptions import ImproperlyConfigured
 from django.test.testcases import TestCase
 import pytest
 
@@ -32,12 +31,12 @@ class TestSimpleTestCase(DjangoSetupMixin):
         runner = Runner(mock.MagicMock())
         runner.context = Context(runner)
         SimpleTestRunner().before_scenario(runner.context)
-        with pytest.raises(ImproperlyConfigured):
+        with pytest.raises(AssertionError):
             assert runner.context.base_url == 'should raise an exception!'
 
     def test_simple_testcase_fails_when_calling_get_url(self):
         runner = Runner(mock.MagicMock())
         runner.context = Context(runner)
         SimpleTestRunner().before_scenario(runner.context)
-        with pytest.raises(ImproperlyConfigured):
+        with pytest.raises(AssertionError):
             runner.context.get_url()

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
     py27: mock
 commands =
     py.test
-    {envpython} manage.py behave --simple --tags=~@failing --tags=~@no-simple --format=progress
+    {envpython} manage.py behave --simple --tags=~@failing --tags=~@requires-live-http --format=progress
     {envpython} manage.py behave --tags=~@failing --format=progress
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps =
     py27: mock
 commands =
     py.test
+    {envpython} manage.py behave --simple --tags=~@failing --tags=~@no-simple --format=progress
     {envpython} manage.py behave --tags=~@failing --format=progress
 
 [testenv:docs]


### PR DESCRIPTION
Adds `--simple` and `-S` flag instructing behave-django to use Django's default `TestCase` instead of `StaticLiveServerTestCase`.

Currently `behave_django` uses `StaticLiveServerTestCase` to make it possible using a test HTTP server and emulate browser requests. But sometimes it's not necessary, and test can run much faster using Django's simple default `TestCase` which rollbacks database transactions instead of flushing the database after each scenario.

Also, `--keepdb` option doesn't work well when database is flushed. We've experienced this issue, which is described here: http://5minutes.youkidea.com/transactiontestcase-keepdb-django-issues.html