### PR TITLE
Update list of possible behave config file names (align w/ behave docs)

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -166,8 +166,9 @@ Behave configuration file
 -------------------------
 
 You can use behave’s configuration file.  Just create a ``behave.ini``,
-``.behaverc``, or ``setup.cfg`` file in your project’s root directory and
-behave will pick it up.  You can read more about it in the `behave docs`_.
+``.behaverc``, ``setup.cfg`` or ``tox.ini`` file in your project’s root
+directory and behave will pick it up.  You can read more about it in the
+`behave docs`_.
 
 For example, if you want to have your features directory somewhere else.
 In your .behaverc file, you can put


### PR DESCRIPTION
`behave` allows `tox.ini` as an additional config file name in the current development version.