### PR TITLE
Add Python 3.6 and Django 1.11 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: python
-python: 3.5
+python: 3.6
 env:  # $ tox -l | sort | xargs -I _ echo '  - TOXENV=_'
   - TOXENV=flake8
   - TOXENV=py27-django18
-  - TOXENV=py27-django19
   - TOXENV=py27-django110
-  - TOXENV=py33-django18
+  - TOXENV=py27-django111
   - TOXENV=py34-django18
-  - TOXENV=py34-django19
   - TOXENV=py34-django110
+  - TOXENV=py34-django111
   - TOXENV=py35-django18
-  - TOXENV=py35-django19
   - TOXENV=py35-django110
+  - TOXENV=py35-django111
+  - TOXENV=py36-django111
 install:
   - pip install tox
 script: tox

--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,8 @@ Version Support
 ---------------
 
 behave-django supports all newer Django versions and their supported Python
-versions.  Specifically, our tests cover Django 1.8 and above on Python 2.7,
-3.3 and above.
+versions.  Specifically, our tests cover Django 1.8, 1.10, 1.11 on
+Python 2.7, 3.4 and above.
 
 The version of `behave`_ is independent from our integration.
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,9 @@
 [tox]
 envlist =
     flake8
-    py{27,33,34,35}-django18
-    py{27,34,35}-django19
+    py{27,34,35}-django18
     py{27,34,35}-django110
+    py{27,34,35,36}-django111
     docs
 
 [testenv]
@@ -17,6 +17,7 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<1.12
     py27: mock
 commands =
     py.test


### PR DESCRIPTION
I also removed Python 3.3 from our test matrix since Travis doesn't seem to
have it anymore. Also removed Django 1.9 since it's unsupported now.

Fixes #32 