### PR TITLE
Make Travis behave with Python 3.5 (pyenv issues)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
-python: 3.5
+python: 3.6
+before_install:
+  # as suggested in https://github.com/travis-ci/travis-ci/issues/4990#issuecomment-297863117
+  - if [[ $TOXENV = py35 && -f ~/virtualenv/python3.5/bin/activate ]]; then source ~/virtualenv/python3.5/bin/activate; fi
 env:  # $ tox -l | sort | xargs -I _ echo '  - TOXENV=_'
   - TOXENV=flake8
   - TOXENV=py27-django18

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: python
 python: 3.6
-before_install:
-  # as suggested in https://github.com/travis-ci/travis-ci/issues/4990#issuecomment-297863117
-  - if [[ $TOXENV = py35 && -f ~/virtualenv/python3.5/bin/activate ]]; then source ~/virtualenv/python3.5/bin/activate; fi
 env:  # $ tox -l | sort | xargs -I _ echo '  - TOXENV=_'
   - TOXENV=flake8
   - TOXENV=py27-django18
@@ -15,6 +12,9 @@ env:  # $ tox -l | sort | xargs -I _ echo '  - TOXENV=_'
   - TOXENV=py35-django110
   - TOXENV=py35-django111
   - TOXENV=py36-django111
+before_install:
+  # work around https://github.com/travis-ci/travis-ci/issues/8363
+  - pyenv global system 3.5
 install:
   - pip install tox
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 3.6
+python: 3.5
 env:  # $ tox -l | sort | xargs -I _ echo '  - TOXENV=_'
   - TOXENV=flake8
   - TOXENV=py27-django18

--- a/tox.ini
+++ b/tox.ini
@@ -12,12 +12,6 @@ envlist =
     docs
 
 [testenv]
-basepython =
-    py27: python2.7
-    py33: python3.3
-    py34: python3.4
-    py35: python3.5
-    py36: python3.6
 deps =
     pytest
     django18: Django>=1.8,<1.9

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,12 @@ envlist =
     docs
 
 [testenv]
+basepython =
+    py27: python2.7
+    py33: python3.3
+    py34: python3.4
+    py35: python3.5
+    py36: python3.6
 deps =
     pytest
     django18: Django>=1.8,<1.9


### PR DESCRIPTION
Tries to fix the following issue for tests running against Python 3.5 on Travis:

> ERROR: Error creating virtualenv. Note that some special characters (e.g. ':' and unicode symbols) in paths are not supported by virtualenv. Error details: InvocationError('Failed to get version_info for python3.5: b"pyenv: python3.5: command not found\\n\\nThe `python3.5\' command exists in these Python versions:\\n  3.5\\n  3.5.3\\n\\n"',)

*Example:* Travis job [#280610286](https://travis-ci.org/behave/behave-django/jobs/280610286)