### PR TITLE
Update how tests are executed

### DIFF
--- a/behave_django/testcase.py
+++ b/behave_django/testcase.py
@@ -2,15 +2,34 @@ from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.test.testcases import TestCase
 
 
-class BehaviorDrivenTestCase(StaticLiveServerTestCase):
+class BehaviorDrivenTestMixin(object):
+    """
+    Mixin to prevent the TestCase from executing its setup and teardown methods
+
+    This mixin overrides the test case's _pre_setup and _post_teardown methods
+    in order to prevent them from executing when the test case is instantiated.
+    We do this to have total control over the test execution.
+    """
+
+    def _pre_setup(self, run=False):
+        if run:
+            super(BehaviorDrivenTestMixin, self)._pre_setup()
+
+    def _post_teardown(self, run=False):
+        if run:
+            super(BehaviorDrivenTestMixin, self)._post_teardown()
+
+    def runTest(self):
+        pass
+
+
+class BehaviorDrivenTestCase(BehaviorDrivenTestMixin,
+                             StaticLiveServerTestCase):
     """
     Test case attached to the context during behave execution
 
     This test case prevents the regular tests from running.
     """
-
-    def runTest(self):
-        pass
 
 
 class ExistingDatabaseTestCase(BehaviorDrivenTestCase):
@@ -27,7 +46,7 @@ class ExistingDatabaseTestCase(BehaviorDrivenTestCase):
         pass
 
 
-class DjangoSimpleTestCase(TestCase):
+class DjangoSimpleTestCase(BehaviorDrivenTestMixin, TestCase):
     """
     Test case attached to the context during behave execution
 
@@ -41,6 +60,3 @@ class DjangoSimpleTestCase(TestCase):
 
     Also, it prevents the regular tests from running.
     """
-
-    def runTest(self):
-        pass

--- a/features/environment.py
+++ b/features/environment.py
@@ -11,3 +11,7 @@ def before_feature(context, feature):
 def before_scenario(context, scenario):
     if scenario.name == 'Load fixtures for this scenario and feature':
         context.fixtures.append('behave-second-fixture.json')
+
+    if scenario.name == 'Load fixtures then reset sequences':
+        context.fixtures.append('behave-second-fixture.json')
+        context.reset_sequences = True

--- a/features/fixture-loading.feature
+++ b/features/fixture-loading.feature
@@ -1,3 +1,4 @@
+@requires-live-http
 Feature: Fixture loading
     In order to have sample data during my behave tests
     As the Maintainer
@@ -8,3 +9,7 @@ Feature: Fixture loading
 
     Scenario: Load fixtures for this scenario and feature
         Then the fixture for the second scenario should be loaded
+
+    @failing
+    Scenario: Load fixtures then reset sequences
+        Then the sequences should be reset

--- a/features/steps/fixture-loading.py
+++ b/features/steps/fixture-loading.py
@@ -11,3 +11,9 @@ def check_fixtures(context):
 @then(u'the fixture for the second scenario should be loaded')
 def check_second_fixtures(context):
     context.test.assertEqual(BehaveTestModel.objects.count(), 2)
+
+
+@then(u'the sequences should be reset')
+def check_reset_seqeunces(context):
+    context.test.assertEqual(BehaveTestModel.objects.first().pk, 1)
+    context.test.assertEqual(BehaveTestModel.objects.last().pk, 2)

--- a/test_app/fixtures/behave-fixtures.json
+++ b/test_app/fixtures/behave-fixtures.json
@@ -3,6 +3,5 @@
         "name": "fixture loading test",
         "number": 42
     },
-    "model": "test_app.behavetestmodel",
-    "pk": 1
+    "model": "test_app.behavetestmodel"
 }]

--- a/test_app/fixtures/behave-second-fixture.json
+++ b/test_app/fixtures/behave-second-fixture.json
@@ -3,6 +3,5 @@
         "name": "second fixture",
         "number": 7
     },
-    "model": "test_app.behavetestmodel",
-    "pk": 2
+    "model": "test_app.behavetestmodel"
 }]

--- a/tests/test_simple_testcase.py
+++ b/tests/test_simple_testcase.py
@@ -30,6 +30,7 @@ class TestSimpleTestCase(DjangoSetupMixin):
     def test_simple_testcase_fails_when_accessing_base_url(self):
         runner = Runner(mock.MagicMock())
         runner.context = Context(runner)
+        SimpleTestRunner().patch_context(runner.context)
         SimpleTestRunner().before_scenario(runner.context)
         with pytest.raises(AssertionError):
             assert runner.context.base_url == 'should raise an exception!'
@@ -37,6 +38,7 @@ class TestSimpleTestCase(DjangoSetupMixin):
     def test_simple_testcase_fails_when_calling_get_url(self):
         runner = Runner(mock.MagicMock())
         runner.context = Context(runner)
+        SimpleTestRunner().patch_context(runner.context)
         SimpleTestRunner().before_scenario(runner.context)
         with pytest.raises(AssertionError):
             runner.context.get_url()


### PR DESCRIPTION
This PR aims to improve the way tests are executed. Specifically, it
makes it so that fixtures are loaded and unloaded by the TestCase.
Issues with the fixture loading was reported in #36.

Currently, fixtures are loaded via the `loaddata` command and we rely on
the transaction to clear it at the end of the test. It turns out that
this isn't a good way of doing it and there are a lot of bugs associated
with sequences and primary keys.

So instead, we'll rely on Django's TestCase (whichever one is used) to
load and clear the fixtures. As a bonus, this also lets us use the
`reset_sequences` feature.