### PR TITLE
Update references to behave docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Please, read the `contributing guide`_ in the docs.
 .. _behave: https://pypi.python.org/pypi/behave
 .. _version 0.3.0: https://pypi.python.org/pypi/behave-django/0.3.0
 .. _behave-django.readthedocs.io: https://behave-django.readthedocs.io/en/latest/
-.. _behave.readthedocs.io: https://behave.readthedocs.io/en/latest/django.html
+.. _behave.readthedocs.io: https://behave.readthedocs.io/en/latest/usecase_django.html
 .. _contributing guide: https://behave-django.readthedocs.io/en/latest/contribute.html
 .. |latest-version| image:: https://img.shields.io/pypi/v/behave-django.svg
     :target: https://pypi.python.org/pypi/behave-django/

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -56,4 +56,4 @@ details of this very example.  See the folder also for `more useful examples`_.
 .. _running-tests.feature: https://github.com/behave/behave-django/blob/master/features/running-tests.feature
 .. _steps/running_tests.py: https://github.com/behave/behave-django/blob/master/features/steps/running_tests.py
 .. _more useful examples: https://github.com/behave/behave-django/tree/master/features
-.. _behave docs: https://behave.readthedocs.io/en/latest/django.html#automation-libraries
+.. _behave docs: https://behave.readthedocs.io/en/latest/practical_tips.html


### PR DESCRIPTION
The URL path and content of [behave](https://behave.readthedocs.io/en/latest/)'s Django chapter changed recently. This PR fixes our references in the README and our docs.