### PR TITLE
Refactor monkey patching

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 Release History
 ---------------
 
+Unreleased
+++++++++++
+
+**Features and Improvements**
+
+- Added :code:`django_ready` hook for running setup code within the django environment
+
+
 1.0.0 (2017-10-25)
 ++++++++++++++++++
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -15,3 +15,7 @@ def before_scenario(context, scenario):
     if scenario.name == 'Load fixtures then reset sequences':
         context.fixtures.append('behave-second-fixture.json')
         context.reset_sequences = True
+
+
+def django_ready(context):
+    context.django = True

--- a/features/running-tests.feature
+++ b/features/running-tests.feature
@@ -7,3 +7,7 @@ Feature: Running tests
         Given this step exists
         When I run "python manage.py behave"
         Then I should see the behave tests run
+
+    Scenario: Test django_ready
+        When I run "python manage.py behave"
+        Then django_ready should be called

--- a/features/steps/running_tests.py
+++ b/features/steps/running_tests.py
@@ -14,3 +14,8 @@ def run_command(context):
 @then(u'I should see the behave tests run')
 def is_running(context):
     pass
+
+
+@then(u'django_ready should be called')
+def django_context(context):
+    assert context.django

--- a/tests/test_simple_testcase.py
+++ b/tests/test_simple_testcase.py
@@ -24,14 +24,14 @@ class TestSimpleTestCase(DjangoSetupMixin):
     def test_simple_test_runner_uses_simple_testcase(self):
         runner = mock.MagicMock()
         context = Context(runner)
-        SimpleTestRunner().before_scenario(context)
+        SimpleTestRunner().setup_testclass(context)
         assert isinstance(context.test, TestCase)
 
     def test_simple_testcase_fails_when_accessing_base_url(self):
         runner = Runner(mock.MagicMock())
         runner.context = Context(runner)
         SimpleTestRunner().patch_context(runner.context)
-        SimpleTestRunner().before_scenario(runner.context)
+        SimpleTestRunner().setup_testclass(runner.context)
         with pytest.raises(AssertionError):
             assert runner.context.base_url == 'should raise an exception!'
 
@@ -39,6 +39,6 @@ class TestSimpleTestCase(DjangoSetupMixin):
         runner = Runner(mock.MagicMock())
         runner.context = Context(runner)
         SimpleTestRunner().patch_context(runner.context)
-        SimpleTestRunner().before_scenario(runner.context)
+        SimpleTestRunner().setup_testclass(runner.context)
         with pytest.raises(AssertionError):
             runner.context.get_url()


### PR DESCRIPTION
This fixes the regression in 1.0.0 where the `test` instance is no longer
available during the `before_scenario` hook.

This PR adds a new `django_setup` hook where you can run Django aware code
before each scenario. The `test` instance is made available in the context and
the method is run inside a transaction.

- [x] Add docs
- [x] Update CHANGELOG

Fixes #46 