### PR TITLE
Add option to set multi_db on TestCase

### DIFF
--- a/behave_django/environment.py
+++ b/behave_django/environment.py
@@ -64,6 +64,9 @@ class BehaveHooksMixin(object):
         if getattr(context, 'reset_sequences', None):
             context.test.reset_sequences = context.reset_sequences
 
+        if getattr(context, 'multi_db', None):
+            context.test.__class__.multi_db = context.multi_db
+
         if hasattr(context, 'scenario'):
             load_registered_fixtures(context)
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -189,6 +189,22 @@ a convenient way to keep fixtures close to your steps.
         pass
 
 
+Support for multiple databases
+******************************
+
+By default Django only loads fixtures into the ``default`` database.
+
+Use ``before_scenario`` to load the fixtures in all of the databases you have
+configured, if your tests rely on the fixtures being loaded in all of them.
+
+.. code-block:: python
+
+    def before_scenario(context, scenario):
+        context.multi_db = True
+
+You can read more about it in the `Multiple database docs`_.
+
+
 Command line options
 --------------------
 
@@ -253,3 +269,4 @@ Behave should now look for your features in those folders.
 .. _keepdb docs: https://docs.djangoproject.com/en/stable/topics/testing/overview/#the-test-database
 .. _using the ORM: https://docs.djangoproject.com/en/stable/topics/testing/tools/#fixture-loading
 .. _Django fixtures: https://docs.djangoproject.com/en/stable/howto/initial-data/#providing-initial-data-with-fixtures
+.. _Multiple database docs: https://docs.djangoproject.com/en/stable/topics/testing/tools/#multi-database-support

--- a/features/environment.py
+++ b/features/environment.py
@@ -16,6 +16,9 @@ def before_scenario(context, scenario):
         context.fixtures.append('behave-second-fixture.json')
         context.reset_sequences = True
 
+    if scenario.name == 'Load fixtures with multi_db option':
+        context.multi_db = True
+
 
 def django_ready(context):
     context.django = True

--- a/features/fixture-loading.feature
+++ b/features/fixture-loading.feature
@@ -13,3 +13,6 @@ Feature: Fixture loading
     @failing
     Scenario: Load fixtures then reset sequences
         Then the sequences should be reset
+
+    Scenario: Load fixtures with multi_db option
+        Then multi_db should be enabled

--- a/features/steps/fixture-loading.py
+++ b/features/steps/fixture-loading.py
@@ -27,6 +27,11 @@ def check_second_fixtures(context):
 
 
 @then(u'the sequences should be reset')
-def check_reset_seqeunces(context):
+def check_reset_sequences(context):
     context.test.assertEqual(BehaveTestModel.objects.first().pk, 1)
     context.test.assertEqual(BehaveTestModel.objects.last().pk, 2)
+
+
+@then(u'multi_db should be enabled')
+def check_multi_db(context):
+    context.test.assertTrue(context.test.multi_db)

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ envlist =
 
 [testenv]
 deps =
+    behave==1.2.5
     py{27,34,35,36}: pytest
     py33: pytest<3.3.0
     py27: mock


### PR DESCRIPTION
By default fixtures are only loaded into the `default` database. If you have multiple databases in order to get the fixtures loaded into all of the databases you have to set `multi_db=True` on the TestCase.

This change allows you to specify multi_db in the `before_scenario` function.