### PR TITLE
Use Codacy (instead of Landscape) for static code analysis

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,8 +59,8 @@ Please, read the `contributing guide`_ in the docs.
 .. |build-status| image:: https://img.shields.io/travis/behave/behave-django/master.svg
     :target: https://travis-ci.org/behave/behave-django
     :alt: Build status
-.. |health| image:: https://landscape.io/github/behave/behave-django/master/landscape.svg?style=flat
-    :target: https://landscape.io/github/behave/behave-django/master
+.. |health| image:: https://api.codacy.com/project/badge/Grade/ffcbf7a0c11445a6b95adf80ac9da029
+    :target: https://www.codacy.com/app/bittner/behave-django
     :alt: Code health
 .. |python-support| image:: https://img.shields.io/pypi/pyversions/behave-django.svg
    :target: https://pypi.python.org/pypi/behave-django

--- a/README.rst
+++ b/README.rst
@@ -59,8 +59,8 @@ Please, read the `contributing guide`_ in the docs.
 .. |build-status| image:: https://img.shields.io/travis/behave/behave-django/master.svg
     :target: https://travis-ci.org/behave/behave-django
     :alt: Build status
-.. |health| image:: https://api.codacy.com/project/badge/Grade/ffcbf7a0c11445a6b95adf80ac9da029
-    :target: https://www.codacy.com/app/bittner/behave-django
+.. |health| image:: https://img.shields.io/codacy/grade/ffcbf7a0c11445a6b95adf80ac9da029/master.svg
+    :target: https://www.codacy.com/app/behave-contrib/behave-django
     :alt: Code health
 .. |python-support| image:: https://img.shields.io/pypi/pyversions/behave-django.svg
    :target: https://pypi.python.org/pypi/behave-django


### PR DESCRIPTION
The Landscape code analysis service (by @carlio) suffers some major issues and lack of maintenance for months - or years - now. This is very sad.

It probably makes sense now to move on to another service to display static code analysis results in a usable and user friendly way. This change adds a badge to Codacy, replacing the old Landscape badge.

**Note:** The link points to my (somewhat) personal account. I've tried to create a "behave" organization on Codacy, but there seems to exist one already (which I have no control over).