### PR TITLE
Replace assert by if+raise in production code

### DIFF
--- a/behave_django/environment.py
+++ b/behave_django/environment.py
@@ -7,9 +7,10 @@ class PatchedContext(Context):
 
     @property
     def base_url(self):
-        assert hasattr(self.test, 'live_server_url'), \
-            'Web browser automation is not available. This ' \
-            'scenario step can not be run with the --simple or -S flag.'
+        if not hasattr(self.test, 'live_server_url'):
+            raise RuntimeError('Web browser automation is not available. '
+                               'This scenario step can not be run with the '
+                               '--simple or -S flag.')
         return self.test.live_server_url
 
     def get_url(self, to=None, *args, **kwargs):

--- a/behave_django/environment.py
+++ b/behave_django/environment.py
@@ -7,11 +7,12 @@ class PatchedContext(Context):
 
     @property
     def base_url(self):
-        if not hasattr(self.test, 'live_server_url'):
+        try:
+            return self.test.live_server_url
+        except AttributeError:
             raise RuntimeError('Web browser automation is not available. '
                                'This scenario step can not be run with the '
                                '--simple or -S flag.')
-        return self.test.live_server_url
 
     def get_url(self, to=None, *args, **kwargs):
         return self.base_url + (

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     license=package.__license__,
     description=package.__doc__.strip(),
     long_description=read_file('README.rst'),
+    long_description_content_type='text/x-rst',
     packages=find_packages(exclude=['test*']),
     include_package_data=True,
     url=package.__url__,

--- a/tests/unit/test_simple_testcase.py
+++ b/tests/unit/test_simple_testcase.py
@@ -34,7 +34,7 @@ class TestSimpleTestCase(DjangoSetupMixin):
         runner.context = Context(runner)
         SimpleTestRunner().patch_context(runner.context)
         SimpleTestRunner().setup_testclass(runner.context)
-        with pytest.raises(AssertionError):
+        with pytest.raises(RuntimeError):
             assert runner.context.base_url == 'should raise an exception!'
 
     def test_simple_testcase_fails_when_calling_get_url(self):
@@ -42,5 +42,5 @@ class TestSimpleTestCase(DjangoSetupMixin):
         runner.context = Context(runner)
         SimpleTestRunner().patch_context(runner.context)
         SimpleTestRunner().setup_testclass(runner.context)
-        with pytest.raises(AssertionError):
+        with pytest.raises(RuntimeError):
             runner.context.get_url()

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ commands =
 
 [testenv:bandit]
 deps = bandit
-commands = bandit .
+commands = bandit -r --ini tox.ini
 
 [testenv:docs]
 deps = sphinx
@@ -41,14 +41,20 @@ deps = flake8
 commands = flake8
 
 [testenv:readme]
-deps = readme_renderer
-commands = {envpython} setup.py check --restructuredtext --strict
+deps = twine
+commands =
+    {envpython} setup.py sdist bdist_wheel
+    twine check dist/*
 
 [travis:env]
 DJANGO =
     1.11: django111
     2.0: django20
     2.1: django21
+
+[bandit]
+targets = behave_django
+exclude = .git,.idea,.tox,build,dist,docs,tests
 
 [behave]
 paths = tests/acceptance


### PR DESCRIPTION
- Fixes running Bandit, the PyCQA security linter, with Tox and Travis CI.
- Fixes a complaint of Bandit (`assert` in production code), adds ignore rules (e.g. for tests).
- Updates the code for verifying the README conversion (as suggested by deprecation warning).

Note that Bandit is also run by Codacy (see PR #84 for details).