### PR TITLE
Deleted obsolete part of docs

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,6 +14,7 @@ Contributors
 * `Jens Engel <https://github.com/jenisys>`_
 * `Jérôme Thiard <https://github.com/jthiard>`_
 * `Karel Hovorka <https://github.com/hovi>`_
+* `Nate Hill <https://github.com/nhill-cpi>`_
 * `Nik Nyby <https://github.com/nikolas>`_
 * `Sebastian Manger <https://github.com/sebastianmanger>`_
 * `Tom Mortimer-Jones <https://github.com/morty>`_

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -5,8 +5,7 @@ Web browser automation
 ----------------------
 
 You can access the test HTTP server from your preferred web automation
-library via ``context.base_url`` (normally, this would be set to
-``http://localhost:8000``).  Alternatively, you can use
+library via ``context.base_url``.  Alternatively, you can use
 ``context.get_url()``, which is a helper function for absolute paths and
 reversing URLs in your Django project.  It takes an absolute path, a view
 name, or a model as an argument, similar to `django.shortcuts.redirect`_.


### PR DESCRIPTION
Deleted obsolete part of docs - HTTP server is no longer usually found at port 8000.