### PR TITLE
Add Django 2.2 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,9 @@ jobs:
   - { stage: lint, python: 3.7, env: TOXENV=readme }
   - { stage: test, python: 3.7, env: TOXENV=behave-latest }
   - stage: deploy
+    python: 3.7
+    env:
+    install: skip
     script: skip
     deploy:
       provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
 - DJANGO=1.11
 - DJANGO=2.0
 - DJANGO=2.1
+- DJANGO=2.2
 
 matrix:
   allow_failures:
@@ -23,6 +24,8 @@ matrix:
   - { env: DJANGO=2.0, python: 2.7 }
   - { env: DJANGO=2.1, python: 2.7 }
   - { env: DJANGO=2.1, python: 3.4 }
+  - { env: DJANGO=2.2, python: 2.7 }
+  - { env: DJANGO=2.2, python: 3.4 }
 
 install:
 - pip install tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ python:
 
 env:
 - DJANGO=1.11
-- DJANGO=2.0
 - DJANGO=2.1
 - DJANGO=2.2
 
@@ -21,7 +20,6 @@ matrix:
   exclude:
   # Python/Django combinations that aren't officially supported
   - { env: DJANGO=1.11, python: 3.7 }
-  - { env: DJANGO=2.0, python: 2.7 }
   - { env: DJANGO=2.1, python: 2.7 }
   - { env: DJANGO=2.1, python: 3.4 }
   - { env: DJANGO=2.2, python: 2.7 }

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Version Support
 ---------------
 
 behave-django is `tested against`_ the officially supported combinations of
-Python and Django (Django 1.11, 2.0, 2.1 on Python 2.7, 3.4, 3.5, 3.6, 3.7).
+Python and Django (Django 1.11, 2.0, 2.1, 2.2 on Python 2.7, 3.4, 3.5, 3.6, 3.7).
 
 The version of `behave`_ is not tied our integration (read: "independent").
 We test against the latest release on PyPI, and run a sample against Behave's

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Version Support
 ---------------
 
 behave-django is `tested against`_ the officially supported combinations of
-Python and Django (Django 1.11, 2.0, 2.1, 2.2 on Python 2.7, 3.4, 3.5, 3.6, 3.7).
+Python and Django (Django 1.11, 2.1, 2.2 on Python 2.7, 3.4, 3.5, 3.6, 3.7).
 
 The version of `behave`_ is not tied our integration (read: "independent").
 We test against the latest release on PyPI, and run a sample against Behave's

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 behave
-Django>=1.11

--- a/tests/test_project/settings.py
+++ b/tests/test_project/settings.py
@@ -2,10 +2,10 @@
 Django settings for test_project project.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.8/topics/settings/
+https://docs.djangoproject.com/en/stable/topics/settings/
 
 For the full list of settings and their values, see
-https://docs.djangoproject.com/en/1.8/ref/settings/
+https://docs.djangoproject.com/en/stable/ref/settings/
 """
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -14,7 +14,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 
 # Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/1.8/howto/deployment/checklist/
+# See https://docs.djangoproject.com/en/stable/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '(&7)ub7ecukla=wzzb1h-u*x3l(93-=r*edcod@%)zn=v7u+@f'
@@ -27,7 +27,7 @@ ALLOWED_HOSTS = []
 
 # Application definition
 
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -36,17 +36,17 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'behave_django',
     'test_app',
-)
+]
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-)
+]
 
 TEMPLATES = [
     {
@@ -57,6 +57,7 @@ TEMPLATES = [
             'debug': DEBUG,
             'context_processors': [
                 'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
             ],
         },
     },
@@ -68,7 +69,7 @@ WSGI_APPLICATION = 'test_project.wsgi.application'
 
 
 # Database
-# https://docs.djangoproject.com/en/1.8/ref/settings/#databases
+# https://docs.djangoproject.com/en/stable/ref/settings/#databases
 
 DATABASES = {
     'default': {
@@ -78,7 +79,7 @@ DATABASES = {
 }
 
 # Internationalization
-# https://docs.djangoproject.com/en/1.8/topics/i18n/
+# https://docs.djangoproject.com/en/stable/topics/i18n/
 
 LANGUAGE_CODE = 'en-us'
 
@@ -92,6 +93,6 @@ USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.8/howto/static-files/
+# https://docs.djangoproject.com/en/stable/howto/static-files/
 
 STATIC_URL = '/static/'

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
     # Python/Django combinations that are officially supported
     py{27,34,35,36}-django111
     py{34,35,36,37}-django20
-    py{35,36,37}-django21
+    py{35,36,37}-django{21,22}
     behave-latest
     bandit
     readme
@@ -20,6 +20,8 @@ deps =
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
+    django22: Django>=2.2,<2.3
+    latest: Django
     latest: git+https://github.com/behave/behave.git#egg=behave
 commands =
     pytest
@@ -51,6 +53,7 @@ DJANGO =
     1.11: django111
     2.0: django20
     2.1: django21
+    2.2: django22
 
 [bandit]
 exclude = .git,.idea,.tox,build,dist,docs,tests

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ envlist =
     flake8
     # Python/Django combinations that are officially supported
     py{27,34,35,36}-django111
-    py{34,35,36,37}-django20
     py{35,36,37}-django{21,22}
     behave-latest
     bandit
@@ -18,9 +17,8 @@ deps =
     py27: mock
     pytest
     django111: Django>=1.11,<2.0
-    django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
-    django22: Django>=2.2,<2.3
+    django22: Django>=2.2,<3.0
     latest: Django
     latest: git+https://github.com/behave/behave.git#egg=behave
 commands =
@@ -51,7 +49,6 @@ commands =
 [travis:env]
 DJANGO =
     1.11: django111
-    2.0: django20
     2.1: django21
     2.2: django22
 


### PR DESCRIPTION
Adds the recently released Django 2.2 to the test matrix and removes Django 2.0, which is officially unsupported since the 2.2 release. Also removes the hard dependency of this project on Django (we assume people know what they are doing).

Fixes #94.