### PR TITLE
Update usage.rst: django_ready() only needs 1 argument

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -101,7 +101,7 @@ basis, you can initialize them in ``environment.py`` like this:
     from myapp.main.tests.factories import UserFactory, RandomContentFactory
 
 
-    def django_ready(context, scenario):
+    def django_ready(context):
         # This function is run inside the transaction
         UserFactory(username='user1')
         UserFactory(username='user2')
@@ -114,7 +114,7 @@ Or maybe you want to modify the ``test`` instance:
     from rest_framework.test import APIClient
 
 
-    def django_ready(context, scenario):
+    def django_ready(context):
         context.test.client = APIClient()
 
 Fixture loading


### PR DESCRIPTION
Hi, we got this error when running behave:
```
HOOK-ERROR in django_ready: TypeError: django_ready() missing 1 required positional argument: 'scenario'
Exception IndexError: tuple index out of range
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/behave/runner.py", line 545, in run_hook
    self.hooks[name](context, *args)
TypeError: django_ready() missing 1 required positional argument: 'scenario'
```

And we found the [code](https://github.com/behave/behave-django/blob/300ba12ebb41521d742ebe2a1719d736f79b8e1a/tests/acceptance/environment.py#L27) of `django_ready` has updated to only one argument.
```py
def django_ready(context):
    ...
```