### PR TITLE
Add PageObject and related classes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,11 +6,14 @@ unreleased
 
 **Features and Improvements**
 
+- Add experimental `Page Object pattern`_ helpers
 - Cover Python 3.8, drop Python 3.4 and Django 1.11 to 2.1 support
 
 **Bugfixes**
 
 - Replace deprecated `multi_db`_ by suggested ``databases`` attribute
+
+.. _Page Object pattern: https://www.martinfowler.com/bliki/PageObject.html
 
 1.3.0 (2019-04-16)
 ++++++++++++++++++

--- a/Pipfile
+++ b/Pipfile
@@ -4,8 +4,9 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+beautifulsoup4 = "*"
 behave = "*"
-Django = ">=1.11"
+Django = ">=2.2"
 
 [dev-packages]
 bandit = "*"

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,7 @@ Features
 - Use behave's command line arguments
 - Use behave's configuration file
 - Fixture loading
+- Page objects
 
 .. support-marker
 

--- a/behave_django/pageobject.py
+++ b/behave_django/pageobject.py
@@ -1,0 +1,128 @@
+"""
+A headless Page Object pattern implementation.
+
+Background reading: https://www.martinfowler.com/bliki/PageObject.html
+"""
+import django.shortcuts
+
+from bs4 import BeautifulSoup
+
+
+class WrongElementError(RuntimeError):
+    """
+    A different PageObject element was expected by the getter from the
+    ```elements`` dictionary.
+    """
+    def __init__(self, element, expected):
+        message = "Expected %s, found %s" % (element.__class__, expected)
+        super(WrongElementError, self).__init__(message)
+
+
+class PageObject:
+    """
+    Headless page object pattern implementation.
+
+    :page:
+        view name, model or URL path for ``django.shortcuts.resolve_url``
+        to load the respective page using the Django test client
+    :elements:
+        Dictionary of elements accessible by helper methods
+    """
+    page = None
+    elements = dict()
+
+    def __init__(self, context):
+        """
+        Load and parse the page specified by the ``page`` class attribute.
+
+        :context:
+            Behave's context patched with Django support by behave-django
+        """
+        urlpath = django.shortcuts.resolve_url(self.__class__.page)
+        self.response = context.test.client.get(urlpath)
+        self.document = BeautifulSoup(self.response.content, 'html.parser')
+        self.request = self.response.request
+        self.context = context
+
+    def __eq__(self, other):
+        """
+        Override default implementation, ignoring changing details of
+        request and response.
+
+        Instead of page we compare the request URL path, which is the
+        resolved value and should always match for equal pages.
+        """
+        return isinstance(other, PageObject) and \
+            self.elements == other.elements and \
+            self.document.string == other.document.string and \
+            self.request == other.request and \
+            self.response.status_code == other.response.status_code
+
+    def _get_element_ensure(self, name, ensure):
+        """
+        Return a subdocument matching the CSS selector of ``elements[name]``
+        and enforcing a requested PageObject element class.
+
+        :raises KeyError:
+            if there is no element configured with the ``name`` key
+        :raises WrongElementError:
+            if the element found for ``name`` doesn't match the requested type
+        """
+        element = self.__class__.elements[name]
+        if isinstance(element, ensure):
+            return element
+        raise WrongElementError(element, expected=ensure)
+
+    def get_element(self, name):
+        """
+        Return a subdocument matching the CSS selector of elements[name].
+        """
+        return self.get_elements(name)[0]
+
+    def get_elements(self, name):
+        """
+        Return all subdocuments matching the CSS selector of elements[name].
+        """
+        element = self._get_element_ensure(name, Element)
+        return self.document.select(element.selector)
+
+    def get_link(self, name):
+        """
+        Return a subdocument matching the CSS selector of elements[name],
+        patched with methods for a link.
+        """
+        return self.get_links(name)[0]
+
+    def get_links(self, name):
+        """
+        Return all subdocuments matching the CSS selector of elements[name],
+        patched with methods for a link.
+        """
+        current_context = self.context
+        element = self._get_element_ensure(name, Link)
+        links = self.document.select(element.selector)
+        for link in links:
+            def click():
+                """Visit a link, load related URL, return a PageObject"""
+                href = link.get('href')
+
+                class NewPageObject(PageObject):
+                    page = href
+
+                return NewPageObject(current_context)
+            link.click = click
+        return links
+
+
+class Element:
+    """An arbitrary HTML element"""
+
+    def __init__(self, css):
+        self.selector = css
+
+
+class Link(Element):
+    """A HTML anchor element representing a hyperlink"""
+
+    def __init__(self, css):
+        super(Link, self).__init__(css)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Contents
    testclient
    isolation
    fixtures
+   pageobject
    setup
    configuration
    contribute

--- a/docs/pageobject.rst
+++ b/docs/pageobject.rst
@@ -1,0 +1,106 @@
+Using Page Objects
+==================
+
+.. warning::
+
+    This is an *alpha* feature.  It may be removed or its underlying
+    implementation changed without a deprecation process!  Please follow the
+    discussions in `related issues`_ or on `Gitter`_ if you plan to use it.
+
+With *behave-django* you can use the `Page Object pattern`_ and work on a
+natural abstraction layer for the content or behavior your web application
+produces.  This is a popular approach to make your tests more stable and
+your code easier to read.
+
+.. code-block:: python
+
+    # FILE: steps/pageobjects/pages.py
+    from behave_django.pageobject import PageObject, Link
+
+    class Welcome(PageObject):
+        page = 'home'  # view name, model or URL path
+        elements = {
+            'about': Link(css='footer a[role=about]'),
+        }
+
+    class About(PageObject):
+        page = 'about'
+
+.. code-block:: python
+
+    # FILE: steps/welcome.py
+    from pageobjects.pages import About, Welcome
+
+    @given(u'I am on the Welcome page')
+    def step_impl(context):
+        context.welcome_page = Welcome(context)
+        assert context.welcome_page.response.status_code == 200
+
+    @when(u'I click on the "About" link')
+    def step_impl(context):
+        context.target_page = \
+            context.welcome_page.get_link('about').click()
+        assert context.target_page.response.status_code == 200
+
+    @then(u'The About page is loaded')
+    def step_impl(context):
+        assert About(context) == context.target_page
+
+A ``PageObject`` instance automatically loads and parses the page you
+specify by its ``page`` attribute.  You then have access to the following
+attributes:
+
+``request``
+    The HTTP request used by the Django test client to fetch the document.
+    This is merely a convenient alias for ``response.request``.
+
+``response``
+    The Django test client's HTTP response object.  Use this to verify the
+    actual HTTP response related to the retrieved document.
+
+``document``
+    The parsed content of the response.  This is, technically speaking, a
+    `Beautiful Soup`_ object.  You *can* use this to access and verify any
+    part of the document content, though it's recommended that you only
+    access the elements you specify with the ``elements`` attribute, using
+    the appropriate helper methods.
+
+Helpers to access your page object's elements:
+
+``get_link(name) -> Link``
+    A subdocument representing a HTML anchor link, retrieved from
+    ``document`` using the CSS selector specified in ``elements[name]``.
+    The returned ``Link`` object provides a ``click()`` method to trigger
+    loading the link's URL, which again returns a ``PageObject``.
+
+.. note::
+
+    *behave-django*'s `PageObject`_ is a headless page object, meaning
+    that it doesn't use Selenium to drive the user interface.
+
+    If you need a page object that encapsulates Selenium you may take a look
+    at alternative libraries, such as `page-object`_, `page-objects`_ or
+    `selenium-page-factory`_.  But keep in mind that this is a different
+    kind of testing:
+
+    - You'll be testing the Web browser, hence for Web browser compatibility.
+    - Preparing an environment for test automation will be laborious.
+    - Mocking objects in your tests will be difficult, if not impossible.
+    - Your tests will be *significantly* slower and potentially brittle.
+
+    Think twice if that is really what you need.  In most cases you'll be
+    better off testing your Django application code only.  That's when you
+    would use `Django's test client`_ and our headless page object.
+
+
+.. _related issues: https://github.com/behave/behave-django/issues
+.. _Gitter: https://gitter.im/behave/behave-django
+.. _Page Object pattern: https://www.martinfowler.com/bliki/PageObject.html
+.. _Beautiful Soup: https://www.crummy.com/software/BeautifulSoup/bs4/doc/
+.. _PageObject:
+    https://github.com/behave/behave-django/blob/master/behave_django/pageobject.py
+.. _page-object: https://pypi.org/project/page-object/
+.. _page-objects: https://pypi.org/project/page-objects/
+.. _selenium-page-factory: https://pypi.org/project/selenium-page-factory/
+.. _Django's test client:
+    https://docs.djangoproject.com/en/stable/topics/testing/tools/#the-test-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+beautifulsoup4
 behave

--- a/tests/acceptance/features/using-pageobject.feature
+++ b/tests/acceptance/features/using-pageobject.feature
@@ -1,0 +1,12 @@
+@requires-live-http
+Feature: Using page objects works as documented
+    In order to ensure that page objects can be used as documented
+    As the Maintainer
+    I want to test all suggested uses
+
+    Scenario: Welcome page object returns a valid (Beautiful Soup) document
+        When I instantiate the Welcome page object
+        Then it provides a valid Beautiful Soup document
+        And get_link() returns the link subdocument
+        When I call click() on the link
+        Then it loads a new PageObject

--- a/tests/acceptance/steps/pageobjects/pages.py
+++ b/tests/acceptance/steps/pageobjects/pages.py
@@ -1,0 +1,12 @@
+from behave_django.pageobject import PageObject, Link
+
+
+class Welcome(PageObject):
+    page = 'home'  # view name, model or URL path
+    elements = {
+        'about': Link(css='footer a[role=about]'),
+    }
+
+
+class About(PageObject):
+    page = 'about'

--- a/tests/acceptance/steps/using_pageobjects.py
+++ b/tests/acceptance/steps/using_pageobjects.py
@@ -1,0 +1,37 @@
+from bs4 import BeautifulSoup
+from bs4.element import Tag
+from behave import then, when
+
+from pageobjects.pages import About, Welcome
+
+
+@when(u'I instantiate the Welcome page object')
+def new_pageobject(context):
+    context.page = Welcome(context)
+
+
+@then(u'it provides a valid Beautiful Soup document')
+def pageobject_works(context):
+    assert context.page.response.status_code == 200
+    assert context.page.request == context.page.response.request
+    assert isinstance(context.page.document, BeautifulSoup)
+    assert 'Test App: behave-django' == context.page.document.title.string, \
+        "unexpected title: %s" % context.page.document.title.string
+
+
+@then(u'get_link() returns the link subdocument')
+def getlink_subdocument(context):
+    context.about_link = context.page.get_link('about')
+    assert isinstance(context.about_link, Tag), \
+        "should be instance of %s (not %s)" % (
+            Tag.__name__, context.about_link.__class__.__name__)
+
+
+@when('I call click() on the link')
+def linkelement_click(context):
+    context.next_page = context.about_link.click()
+
+
+@then('it loads a new PageObject')
+def click_returns_pageobject(context):
+    assert About(context) == context.next_page

--- a/tests/test_app/templates/about.html
+++ b/tests/test_app/templates/about.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Test App: About Us</title>
+    </head>
+    <body>
+        <h1>About Us</h1>
+    </body>
+</html>

--- a/tests/test_app/templates/index.html
+++ b/tests/test_app/templates/index.html
@@ -1,6 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
+    <head>
+        <title>Test App: behave-django</title>
+    </head>
     <body>
-        Behave Django works
+        <h1>Behave Django works</h1>
+
+        <footer>
+            <a href="{% url 'about' %}" role="about">About Us</a>
+        </footer>
     </body>
 </html>

--- a/tests/test_project/urls.py
+++ b/tests/test_project/urls.py
@@ -1,9 +1,11 @@
-from django.conf.urls import url
 from django.contrib import admin
+from django.urls import path
 from django.views.generic import TemplateView
 
 urlpatterns = [
-    url(r'^$', TemplateView.as_view(template_name='index.html')),
-
-    url(r'^admin/', admin.site.urls),
+    path('', TemplateView.as_view(template_name='index.html'),
+         name='home'),
+    path('about/', TemplateView.as_view(template_name='about.html'),
+         name='about'),
+    path('admin/', admin.site.urls),
 ]


### PR DESCRIPTION
The [Page Object pattern](https://www.martinfowler.com/bliki/PageObject.html) allows to write tests on a natural layer of abstraction, so that you can focus on the external behavior of your web application instead of the internal structure. This is a popular approach to make your tests more stable and your test code easier to read.

The implementation is experimental and hence marked as "alpha" feature in the documentation. Once user feedback confirms that the approach is fruitful we can release version 2.0.0, which should declare the interface stable and also finally remove all traces of Python 2.7 still in the code base.

Closes #108