### PR TITLE
Also cover Django 3.1 with test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
 env:
 - DJANGO=2.2
 - DJANGO=3.0
+- DJANGO=3.1
 
 install:
 - pip install tox-travis
@@ -27,6 +28,7 @@ jobs:
   exclude:
   # Python/Django combinations that aren't officially supported
   - { python: 3.5, env: DJANGO=3.0 }
+  - { python: 3.5, env: DJANGO=3.1 }
   include:
   - { stage: lint, python: 3.7, env: TOXENV=flake8 }
   - { stage: lint, python: 3.7, env: TOXENV=bandit }

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Version Support
 ---------------
 
 *behave-django* is `tested against`_ the officially supported combinations of
-Python and Django (Django 2.2, 3.0 on Python 3.5, 3.6, 3.7, 3.8).
+Python and Django (Django 2.2, 3.0, 3.1 on Python 3.5, 3.6, 3.7, 3.8).
 
 The version of `behave`_ is not tied to our integration (read: "independent").
 We test against the latest release on PyPI, and run a sample against Behave's

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
     # Python/Django combinations that are officially supported
     py{35,36,37,38}-django22
     py{36,37,38}-django30
+    py{36,37,38}-django31
     behave-latest
     bandit
     readme
@@ -19,6 +20,7 @@ deps =
     pytest
     django22: Django>=2.2,<3.0
     django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
     latest: Django
     latest: git+https://github.com/behave/behave.git#egg=behave
 commands =
@@ -33,12 +35,11 @@ commands = bandit -r --ini tox.ini
 
 [testenv:clean]
 description = Remove Python bytecode and other debris
+deps = pyclean
 commands =
+    pyclean -v {toxinidir}
     rm -rf .tox/ behave_django.egg-info/ build/ dist/ docs/_build/
-    find {toxinidir} -type f -name '*.pyc' -delete
-    find {toxinidir} -type d -name '__pycache__' -delete
 whitelist_externals =
-    find
     rm
 
 [testenv:docs]
@@ -64,6 +65,7 @@ commands =
 DJANGO =
     2.2: django22
     3.0: django30
+    3.1: django31
 
 [bandit]
 exclude = .git,.idea,.tox,build,dist,docs,tests


### PR DESCRIPTION
This adds Django 3.1 to our test suite. Python 3.9 is still not covered, simply by the fact that no stable Django release officially supports 3.9 (so we can save ourselves the headache to find out whether Travis already supports Python 3.9, haha).