### PR TITLE
Switch default branch to remove discriminating wording

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,10 +3,10 @@ name: Checks
 on:
   pull_request:
     branches:
-    - master
+    - main
   push:
     branches:
-    - master
+    - main
 
 jobs:
   check:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: Tests
 on:
   pull_request:
     branches:
-    - master
+    - main
   push:
     branches:
-    - master
+    - main
 
 jobs:
   python-django:

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 behave-django |latest-version|
 ==============================
 
-|test-status| |check-status| |health| |python-support| |license| |docs-status| |gitter|
+|check-status| |test-status| |python-support| |license| |docs-status| |gitter|
 
 Behave BDD integration for Django
 
@@ -57,15 +57,12 @@ Please, read the `contributing guide`_ in the docs.
 .. |latest-version| image:: https://img.shields.io/pypi/v/behave-django.svg
     :target: https://pypi.org/project/behave-django/
     :alt: Latest version
-.. |test-status| image:: https://github.com/behave/behave-django/actions/workflows/check.yml/badge.svg
+.. |check-status| image:: https://github.com/behave/behave-django/actions/workflows/check.yml/badge.svg
     :target: https://github.com/behave/behave-django/actions/workflows/check.yml
-    :alt: Build status
-.. |check-status| image:: https://github.com/behave/behave-django/actions/workflows/test.yml/badge.svg
+    :alt: Code checks status
+.. |test-status| image:: https://github.com/behave/behave-django/actions/workflows/test.yml/badge.svg
     :target: https://github.com/behave/behave-django/actions/workflows/test.yml
-    :alt: Build status
-.. |health| image:: https://img.shields.io/codacy/grade/ffcbf7a0c11445a6b95adf80ac9da029/master.svg
-    :target: https://www.codacy.com/app/behave-contrib/behave-django
-    :alt: Code health
+    :alt: Test suite status
 .. |python-support| image:: https://img.shields.io/pypi/pyversions/behave-django.svg
     :target: https://pypi.org/project/behave-django/
     :alt: Python versions

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Python and Django (Django 2.2, 3.2, 4.0 on Python 3.6, 3.7, 3.8, 3.9, 3.10).
 
 The version of `behave`_ is not tied to our integration (read: "independent").
 We test against the latest release on PyPI, and run a sample against Behave's
-current ``master`` branch.
+current ``main`` branch.
 
 .. docs-marker
 
@@ -67,7 +67,7 @@ Please, read the `contributing guide`_ in the docs.
     :target: https://pypi.org/project/behave-django/
     :alt: Python versions
 .. |license| image:: https://img.shields.io/pypi/l/behave-django.svg
-    :target: https://github.com/behave/behave-django/blob/master/LICENSE
+    :target: https://github.com/behave/behave-django/blob/main/LICENSE
     :alt: Software license
 .. |docs-status| image:: https://img.shields.io/readthedocs/behave-django/stable.svg
     :target: https://readthedocs.org/projects/behave-django/

--- a/docs/pageobject.rst
+++ b/docs/pageobject.rst
@@ -98,7 +98,7 @@ Helpers to access your page object's elements:
 .. _Page Object pattern: https://www.martinfowler.com/bliki/PageObject.html
 .. _Beautiful Soup: https://www.crummy.com/software/BeautifulSoup/bs4/doc/
 .. _PageObject:
-    https://github.com/behave/behave-django/blob/master/behave_django/pageobject.py
+    https://github.com/behave/behave-django/blob/main/behave_django/pageobject.py
 .. _page-object: https://pypi.org/project/page-object/
 .. _page-objects: https://pypi.org/project/page-objects/
 .. _selenium-page-factory: https://pypi.org/project/selenium-page-factory/

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -71,8 +71,8 @@ tests folder.
    The `behave docs`_ provide additional helpful information on using *behave*
    with Django and various test automation libraries.
 
-.. _environment.py: https://github.com/behave/behave-django/blob/master/tests/acceptance/environment.py
-.. _running-tests.feature: https://github.com/behave/behave-django/blob/master/tests/acceptance/features/running-tests.feature
-.. _more useful examples: https://github.com/behave/behave-django/tree/master/tests/acceptance/features
-.. _steps/running_tests.py: https://github.com/behave/behave-django/blob/master/tests/acceptance/steps/running_tests.py
+.. _environment.py: https://github.com/behave/behave-django/blob/main/tests/acceptance/environment.py
+.. _running-tests.feature: https://github.com/behave/behave-django/blob/main/tests/acceptance/features/running-tests.feature
+.. _more useful examples: https://github.com/behave/behave-django/tree/main/tests/acceptance/features
+.. _steps/running_tests.py: https://github.com/behave/behave-django/blob/main/tests/acceptance/steps/running_tests.py
 .. _behave docs: https://behave.readthedocs.io/en/latest/practical_tips.html


### PR DESCRIPTION
Following the example of our industry, also this project changes the name of the default branch to remove slavery terms.

Also fixes some issues with the badges in the project README.