### PR TITLE
Align test project settings with current Django versions (3.2/4.0)

### DIFF
--- a/tests/test_project/settings.py
+++ b/tests/test_project/settings.py
@@ -8,11 +8,10 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/stable/ref/settings/
 """
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-import os
+from pathlib import Path
 
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-
+# Build paths inside the project like this: BASE_DIR / 'subdir'.
+BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/stable/howto/deployment/checklist/
@@ -57,6 +56,8 @@ TEMPLATES = [
         'OPTIONS': {
             'debug': DEBUG,
             'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
             ],
@@ -68,14 +69,13 @@ ROOT_URLCONF = 'test_project.urls'
 
 WSGI_APPLICATION = 'test_project.wsgi.application'
 
-
 # Database
 # https://docs.djangoproject.com/en/stable/ref/settings/#databases
 
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'NAME': BASE_DIR / 'db.sqlite3',
     }
 }
 
@@ -83,17 +83,16 @@ DATABASES = {
 # https://docs.djangoproject.com/en/stable/topics/i18n/
 
 LANGUAGE_CODE = 'en-us'
-
 TIME_ZONE = 'UTC'
-
 USE_I18N = True
-
-USE_L10N = True
-
 USE_TZ = True
-
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/stable/howto/static-files/
 
 STATIC_URL = '/static/'
+
+# Default primary key field type
+# https://docs.djangoproject.com/en/stable/ref/settings/#default-auto-field
+
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

--- a/tests/test_project/settings.py
+++ b/tests/test_project/settings.py
@@ -75,7 +75,9 @@ WSGI_APPLICATION = 'test_project.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+        # NOTE: str() is for Django 2.2 compatibility only.
+        # TODO: Revert when Django 2.2 support is dropped.
+        'NAME': str(BASE_DIR / 'db.sqlite3'),
     }
 }
 


### PR DESCRIPTION
The Django settings long use pathlib for operations related to directories and files.
The TEMPLATES[OPTIONS] dictionary has more context processors by default (from Django 1.8 on or earlier).
Django 4.0 now [deprecates the use of the USE_L10N member](https://docs.djangoproject.com/en/4.0/releases/4.0/#use-l10n-deprecation) in the Django settings.
The [DEFAULT_AUTO_FIELD](https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field) is new since Django 3.2 and issues a warning when not explicitly defined.