### PR TITLE
Restore older Bandit version for predictive setup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.7'
     - name: Install prerequisites
       run: python -m pip install --upgrade setuptools pip wheel tox
     - name: Run ${{ matrix.env }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,5 @@
 [tool.bandit]
-exclude = [
-    ".git",
-    ".idea",
-    ".tox",
-    "build",
-    "dist",
-    "docs",
-    "tests",
-]
+# Exclude/ignore of files is currently broken in Bandit.
 
 [tool.black]
 color = true

--- a/tox.ini
+++ b/tox.ini
@@ -31,8 +31,8 @@ commands =
 
 [testenv:bandit]
 description = PyCQA security linter
-deps = bandit
-commands = bandit {posargs:-r behave_django setup}
+deps = bandit<1.6
+commands = bandit --ini tox.ini {posargs:-r .}
 
 [testenv:black]
 description = Ensure consistent code style
@@ -84,6 +84,9 @@ commands =
 paths = tests/acceptance
         tests/test_app
 show_skipped = no
+
+[bandit]
+exclude = .git,.github,.tox,py2clean.py,py3clean.py,pypyclean.py,tests
 
 [flake8]
 exclude = docs,.cache,.tox,*.egg-info,.ropeproject


### PR DESCRIPTION
Bandit UX is seriously broken, only <1.6 works predictably.

Exclude/ignore of files is currently broken in Bandit:
- https://github.com/PyCQA/bandit/issues/693
- https://github.com/PyCQA/bandit/issues/490
- https://github.com/PyCQA/bandit/issues/438#issuecomment-494211922

Reading settings from configuration files is broken:
- https://github.com/PyCQA/bandit/issues/753
- https://github.com/PyCQA/bandit/issues/595

Reading from pyproject.toml not yet functional:
Must install "toml" package and use "-c pyproject.toml".
- https://github.com/PyCQA/bandit/issues/758

INI file configuration and CLI usage is unclear:
- https://github.com/PyCQA/bandit/issues/603
- https://github.com/PyCQA/bandit/issues/467
- https://github.com/PyCQA/bandit/issues/396