### PR TITLE
Speed up linting jobs, rely on defaults for Pip & Coverage

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,10 @@ on:
     branches:
     - main
 
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: '1'
+  PY_COLORS: '1'
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -24,8 +28,8 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.7'
+        python-version: '3.10'
     - name: Install prerequisites
-      run: python -m pip install --upgrade setuptools pip wheel tox
+      run: python -m pip install tox
     - name: Run ${{ matrix.env }}
       run: tox -e ${{ matrix.env }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,13 @@
-name: Publish on PyPI
+name: Publish
 
 on:
   push:
     tags:
     - '*'
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: '1'
+  PY_COLORS: '1'
 
 jobs:
   publish:
@@ -12,11 +16,11 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: Install prerequisites
-      run: python -m pip install --upgrade pip setuptools twine wheel
+      run: python -m pip install build twine wheel
     - name: Build package
-      run: python setup.py sdist bdist_wheel
+      run: python -m build
     - name: Upload to PyPI
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,9 @@ jobs:
         - '3.9'
         - '3.10'
         django-version:
-        - '2.2'
         - '3.2'
         - '4.0'
         exclude:
-        - { django-version: '2.2', python-version: '3.10' }
         - { django-version: '4.0', python-version: '3.6' }
         - { django-version: '4.0', python-version: '3.7' }
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ on:
     branches:
     - main
 
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: '1'
+  PY_COLORS: '1'
+
 jobs:
   python-django:
     runs-on: ubuntu-latest
@@ -34,7 +38,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install prerequisites
-      run: python -m pip install --upgrade pip setuptools tox-gh-actions
+      run: python -m pip install tox-gh-actions
     - name: Run tests (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }})
       run: tox
       env:
@@ -49,6 +53,6 @@ jobs:
       with:
         python-version: '3.10'
     - name: Install prerequisites
-      run: python -m pip install --upgrade pip setuptools tox
+      run: python -m pip install tox
     - name: Run tests (${{ env.TOXENV }})
       run: tox

--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,8 @@ coverage.xml
 nosetests.xml
 .pytest_cache/
 .tox/
-tests/reports/
+tests/TESTS-features.*.xml
+tests/*-report.xml
 
 # Translations
 *.mo

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,12 +3,14 @@ Maintainers
 
 * `Mitchel Cabuloy <https://github.com/mixxorz>`_ (original author)
 * `Peter Bittner <https://github.com/bittner>`_
+* `Javier Buzzi <https://github.com/kingbuzzman>`_
 
 Contributors
 ------------
 
 * `薛丞宏 <https://github.com/sih4sing5hong5>`_
 * `Alex Hutton <https://github.com/alex-hutton>`_
+* `Dave Kwon <https://github.com/Blue-Hope>`_
 * `David Avsajanishvili <https://github.com/avsd>`_
 * `Dolan Antenucci <https://github.com/pydolan>`_
 * `Ivan Rocha <https://github.com/ivancrneto>`_

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,8 @@ Release History
 
 **Features and Improvements**
 
-- Cover Python 3.9 and 3.10 and Django 3.2, drop Python 3.5 and Django 3.0 support
+- Add instructions to measure test coverage to the documentation
+- Cover Python 3.9 and 3.10 and Django 3.2 and 4.0, drop Python 3.5 and Django 2.2 and 3.0 support
 - Bump Behave requirement to 1.2.7 (allows option to change the Behave TestRunner)
 - New option to change the Django TestRunner
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,14 @@
 [tool.bandit]
-# Exclude/ignore of files is currently broken in Bandit.
+exclude_dirs = [".git",".github",".tox","tests"]
 
 [tool.black]
 color = true
 
-[tool.coverage.xml]
-output = "tests/reports/coverage.xml"
+[tool.coverage.run]
+source = ["behave_django"]
+
+[tool.coverage.report]
+show_missing = true
 
 [tool.isort]
 color_output = true
@@ -15,7 +18,7 @@ profile = "black"
 output-format = "colorized"
 
 [tool.pytest.ini_options]
-addopts = "--junitxml=tests/reports/unittests.xml --color=yes --verbose"
+addopts = "--color=yes --junitxml=tests/unittests-report.xml --verbose"
 testpaths = [
     "tests/unit",
 ]

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         'Environment :: Plugins',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Intended Audience :: Developers',

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,5 +1,5 @@
 import os
-from imp import reload
+from importlib import reload
 
 import pytest
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,82 +15,6 @@ envlist =
     docs
     clean
 
-[testenv]
-description = Unit tests
-deps =
-    pytest
-    django22: django~=2.2.26
-    django32: django~=3.2.11
-    django40: django~=4.0.1
-    latest: Django
-    latest: git+https://github.com/behave/behave.git#egg=behave
-commands =
-    pytest
-    {envpython} tests/manage.py behave --simple --tags=~@failing --tags=~@requires-live-http {posargs:--format=progress}
-    {envpython} tests/manage.py behave --tags=~@failing {posargs:--format=progress}
-
-[testenv:bandit]
-description = PyCQA security linter
-deps = bandit<1.6
-commands = bandit --ini tox.ini {posargs:-r .}
-
-[testenv:black]
-description = Ensure consistent code style
-deps = black
-commands = black --check --diff {posargs:behave_django setup.py tests}
-
-[testenv:clean]
-description = Remove Python bytecode and other debris
-deps = pyclean
-commands =
-    pyclean -v {toxinidir}
-    rm -rf .tox/ behave_django.egg-info/ build/ dist/ docs/_build/
-allowlist_externals =
-    rm
-
-[testenv:docs]
-description = Build package documentation (HTML)
-deps = sphinx
-changedir = docs
-commands = make html
-allowlist_externals = make
-
-[testenv:flake8]
-description = Static code analysis and code style
-deps = flake8
-commands = flake8 {posargs}
-
-[testenv:isort]
-description = Ensure imports are ordered consistently
-deps = isort[colors]
-commands = isort --check-only --diff {posargs:behave_django setup tests}
-
-[testenv:pylint]
-description = Check for errors and code smells
-deps =
-    {[testenv]deps}
-    pylint
-commands =
-    pylint {posargs:behave_django setup}
-
-[testenv:readme]
-description = Ensure README renders on PyPI
-deps = twine
-commands =
-    {envpython} setup.py sdist bdist_wheel
-    twine check dist/*
-
-[behave]
-paths = tests/acceptance
-        tests/test_app
-show_skipped = no
-
-[bandit]
-exclude = .git,.github,.tox,py2clean.py,py3clean.py,pypyclean.py,tests
-
-[flake8]
-exclude = docs,.cache,.tox,*.egg-info,.ropeproject
-
 [gh-actions]
 python =
     3.6: py36
@@ -104,3 +28,89 @@ DJANGO =
     2.2: django22
     3.2: django32
     4.0: django40
+
+[testenv]
+description = Unit tests
+deps =
+    django22: django~=2.2.26
+    django32: django~=3.2.11
+    django40: django~=4.0.1
+    latest: Django
+    latest: git+https://github.com/behave/behave.git#egg=behave
+    pytest
+    coverage[toml]
+commands =
+    coverage run -m pytest {posargs}
+    coverage xml
+    coverage report
+    {envpython} tests/manage.py behave --simple --tags=~@failing --tags=~@requires-live-http {posargs:--format=progress}
+    {envpython} tests/manage.py behave --tags=~@failing {posargs:--format=progress}
+
+[testenv:bandit]
+description = PyCQA security linter
+skip_install = true
+deps = bandit[toml]
+commands = bandit {posargs:-c pyproject.toml -r .}
+
+[testenv:black]
+description = Ensure consistent code style
+skip_install = true
+deps = black
+commands = black {posargs:--check --diff behave_django setup.py tests}
+
+[testenv:clean]
+description = Remove Python bytecode and other debris
+skip_install = true
+deps = pyclean
+commands =
+    pyclean {posargs:.}
+    rm -rf .tox/ behave_django.egg-info/ build/ dist/ docs/_build/ .coverage coverage.xml
+    find tests -name 'TESTS-features.*.xml' -delete -or -name '*-report.xml' -delete
+allowlist_externals =
+    find
+    rm
+
+[testenv:docs]
+description = Build package documentation (HTML)
+skip_install = true
+deps = sphinx
+changedir = docs
+commands = make html
+allowlist_externals = make
+
+[testenv:flake8]
+description = Static code analysis and code style
+skip_install = true
+deps = flake8
+commands = flake8 {posargs}
+
+[testenv:isort]
+description = Ensure imports are ordered consistently
+skip_install = true
+deps = isort[colors]
+commands = isort {posargs:--check-only --diff behave_django setup.py tests}
+
+[testenv:pylint]
+description = Check for errors and code smells
+deps = pylint
+commands = pylint {posargs:behave_django setup}
+
+[testenv:readme]
+description = Ensure README renders on PyPI
+skip_install = true
+deps =
+    build
+    twine
+commands =
+    python -m build
+    twine check dist/*
+
+[behave]
+junit = yes
+junit_directory = tests
+paths = tests/acceptance
+        tests/test_app
+show_skipped = no
+
+[flake8]
+exclude = docs,.cache,.tox,*.egg-info,.ropeproject

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ envlist =
     isort
     flake8
     # Python/Django combinations that are officially supported
-    py{36,37,38,39}-django22
     py{36,37,38,39,310}-django32
     py{38,39,310}-django40
     behave-latest
@@ -25,16 +24,14 @@ python =
 
 [gh-actions:env]
 DJANGO =
-    2.2: django22
     3.2: django32
     4.0: django40
 
 [testenv]
 description = Unit tests
 deps =
-    django22: django~=2.2.26
-    django32: django~=3.2.11
-    django40: django~=4.0.1
+    django32: django~=3.2.12
+    django40: django~=4.0.3
     latest: Django
     latest: git+https://github.com/behave/behave.git#egg=behave
     pytest


### PR DESCRIPTION
- Pip is installed natively on Azure for running Python package installations. It's in Microsoft's interest to keep the version sufficiently up-to-date. Hence, we shouldn't need to bother about it.
- For linting jobs we can tell Tox to not install our software as a package, which is only an unnecessary overhead for static inspection.
- We can use the latest version of Bandit when using the appropriate configuration switch for ignoring irrelevant files and directories.
- For coverage and unit test reports it makes sense to stick to the default file names and locations, to avoid the need for explicit configuration and to not confuse contributors and interested developers.