### PR TITLE
Use pylint-django for more tailored Pylint checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,9 +19,10 @@ jobs:
       fail-fast: false
       matrix:
         env:
-        - isort
-        - flake8
         - bandit
+        - flake8
+        - isort
+        - pylint
         - readme
         - docs
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,10 @@
 [tool.bandit]
-exclude_dirs = [".git",".github",".tox","tests"]
+exclude_dirs = [
+    ".git",
+    ".github",
+    ".tox",
+    "tests",
+]
 
 [tool.black]
 color = true
@@ -15,7 +20,17 @@ color_output = true
 profile = "black"
 
 [tool.pylint.master]
+django-settings-module = "test_project.settings"
+init-hook = "import sys; sys.path.append('tests')"
+load-plugins = ["pylint_django"]
 output-format = "colorized"
+
+[tool.pylint.messages_control]
+disable = [
+    "missing-class-docstring",
+    "missing-function-docstring",
+    "missing-module-docstring",
+]
 
 [tool.pytest.ini_options]
 addopts = "--color=yes --junitxml=tests/unittests-report.xml --verbose"

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,14 @@
 
 [tox]
 envlist =
-    isort
+    bandit
     flake8
+    isort
+    pylint
     # Python/Django combinations that are officially supported
     py{36,37,38,39,310}-django32
     py{38,39,310}-django40
     behave-latest
-    bandit
     readme
     docs
     clean
@@ -90,7 +91,7 @@ commands = isort {posargs:--check-only --diff behave_django setup.py tests}
 [testenv:pylint]
 description = Check for errors and code smells
 deps = pylint-django
-commands = pylint {posargs:behave_django setup}
+commands = pylint {posargs:--exit-zero behave_django setup}
 
 [testenv:readme]
 description = Ensure README renders on PyPI

--- a/tox.ini
+++ b/tox.ini
@@ -89,7 +89,7 @@ commands = isort {posargs:--check-only --diff behave_django setup.py tests}
 
 [testenv:pylint]
 description = Check for errors and code smells
-deps = pylint
+deps = pylint-django
 commands = pylint {posargs:behave_django setup}
 
 [testenv:readme]


### PR DESCRIPTION
We don't use Pylint yet to enforce a certain code style and run dynamic linting against the code base. It still makes sense to streamline its configuration, though, and run it locally from time to time, for additional feedback on the code quality.