### PR TITLE
Fix some Pylint complaints, silence false-positives

### DIFF
--- a/behave_django/environment.py
+++ b/behave_django/environment.py
@@ -11,10 +11,10 @@ class PatchedContext(Context):
     def base_url(self):
         try:
             return self.test.live_server_url
-        except AttributeError:
+        except AttributeError as err:
             raise RuntimeError('Web browser automation is not available. '
                                'This scenario step can not be run with the '
-                               '--simple or -S flag.')
+                               '--simple or -S flag.') from err
 
     def get_url(self, to=None, *args, **kwargs):
         return self.base_url + (
@@ -43,7 +43,7 @@ def load_registered_fixtures(context):
             context.test.fixtures.extend(match.func.registered_fixtures)
 
 
-class BehaveHooksMixin(object):
+class BehaveHooksMixin:
     """
     Provides methods that run during test execution
 
@@ -66,7 +66,7 @@ class BehaveHooksMixin(object):
         """
         Adds the test instance to context
         """
-        context.test = self.testcase_class()
+        context.test = self.testcase_class()  # pylint: disable=not-callable
 
     def setup_fixtures(self, context):
         """

--- a/behave_django/pageobject.py
+++ b/behave_django/pageobject.py
@@ -13,8 +13,8 @@ class WrongElementError(RuntimeError):
     ```elements`` dictionary.
     """
     def __init__(self, element, expected):
-        message = "Expected %s, found %s" % (expected, element.__class__)
-        super(WrongElementError, self).__init__(message)
+        message = f"Expected {expected}, found {element.__class__}"
+        super().__init__(message)
 
 
 class PageObject:
@@ -28,7 +28,7 @@ class PageObject:
         Dictionary of elements accessible by helper methods
     """
     page = None
-    elements = dict()
+    elements = {}
 
     def __init__(self, context):
         """
@@ -122,6 +122,3 @@ class Element:
 
 class Link(Element):
     """A HTML anchor element representing a hyperlink"""
-
-    def __init__(self, css):
-        super(Link, self).__init__(css)

--- a/behave_django/testcase.py
+++ b/behave_django/testcase.py
@@ -2,7 +2,7 @@ from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.test.testcases import TestCase
 
 
-class BehaviorDrivenTestMixin(object):
+class BehaviorDrivenTestMixin:
     """
     Mixin to prevent the TestCase from executing its setup and teardown methods
 
@@ -13,13 +13,13 @@ class BehaviorDrivenTestMixin(object):
 
     def _pre_setup(self, run=False):
         if run:
-            super(BehaviorDrivenTestMixin, self)._pre_setup()
+            super()._pre_setup()
 
     def _post_teardown(self, run=False):
         if run:
-            super(BehaviorDrivenTestMixin, self)._post_teardown()
+            super()._post_teardown()
 
-    def runTest(self):
+    def runTest(self):  # pylint: disable=invalid-name
         pass
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,20 +2,18 @@
 """
 Packaging setup of Django integration for behave.
 """
-from os import chdir
-from os.path import abspath, dirname, normpath
+from pathlib import Path
 
 from setuptools import find_packages, setup
 
-# allow setup.py to be run from any path
-chdir(normpath(abspath(dirname(__file__))))
-
-import behave_django as package  # noqa
+import behave_django as package
 
 
 def read_file(filename):
-    with open(filename) as file:
-        return file.read()
+    """Read a text file and return its contents."""
+    project_home = Path(__file__).parent.resolve()
+    file_path = project_home / filename
+    return file_path.read_text(encoding="utf-8")
 
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -41,8 +41,8 @@ commands =
     coverage run -m pytest {posargs}
     coverage xml
     coverage report
-    {envpython} tests/manage.py behave --simple --tags=~@failing --tags=~@requires-live-http {posargs:--format=progress}
-    {envpython} tests/manage.py behave --tags=~@failing {posargs:--format=progress}
+    python tests/manage.py behave --tags=~@failing --tags=~@requires-live-http --simple {posargs}
+    python tests/manage.py behave --tags=~@failing {posargs}
 
 [testenv:bandit]
 description = PyCQA security linter


### PR DESCRIPTION
As we now let Pylint run on GHA, we can identify which complaints are easy to fix. This way, we'll move towards "Pylint conformant" slowly, step by step.

These changes fix the most obvious complaints and silences only those that we _really_ can't do anything about (e.g. because class member names or function parameter names are inherited from / defined by Django).