### PR TITLE
Make behave-django work with behave v1.2.7.dev3

### DIFF
--- a/behave_django/management/commands/behave.py
+++ b/behave_django/management/commands/behave.py
@@ -22,7 +22,8 @@ def valid_python_module(path):
         module = import_module(module_path)
         return getattr(module, class_name)
     except (ValueError, AttributeError, ImportError):
-        raise ArgumentTypeError("No module named '{path}' was found.")
+        msg = f"No module named '{path}' was found."
+        raise ArgumentTypeError(msg)
 
 
 def add_command_arguments(parser):
@@ -66,12 +67,12 @@ def add_command_arguments(parser):
         " testing client only (no web browser automation)"
     )
     parser.add_argument(
-        '--runner-class',
+        '--runner',
         action='store',
         type=valid_python_module,
         default='behave_django.runner.BehaviorDrivenTestRunner',
         help=('Full Python dotted path to a package, module, Django '
-              'TestRunner.  Defaults to "%(default)s)".')
+              'TestRunner.  Defaults to "%(default)s".')
     )
 
 
@@ -82,14 +83,15 @@ def add_behave_arguments(parser):  # noqa
 
     # Option strings that conflict with Django
     conflicts = [
-        '--no-color',
-        '--version',
         '-c',
         '-k',
-        '-v',
+        '-r',
         '-S',
+        '-v',
+        '--no-color',
+        '--runner',
         '--simple',
-        '--runner-class',
+        '--version',
     ]
 
     parser.add_argument(
@@ -140,7 +142,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
 
-        django_runner_class = options['runner_class']
+        django_runner_class = options['runner']
         is_default_runner = django_runner_class is BehaviorDrivenTestRunner
 
         # Check the flags
@@ -154,7 +156,7 @@ class Command(BaseCommand):
         if not is_default_runner and active_flags:
             self.stderr.write(self.style.WARNING(
                 '--use-existing-database or --simple has no effect'
-                ' together with --runner-class'
+                ' together with --runner'
             ))
 
         # Configure django environment

--- a/behave_django/management/commands/behave.py
+++ b/behave_django/management/commands/behave.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import
 
 import sys
+from argparse import ArgumentTypeError
+from importlib import import_module
 
 from behave.__main__ import main as behave_main
 from behave.configuration import options as behave_options
-from behave.configuration import valid_python_module
 from django.core.management.base import BaseCommand
 
 from behave_django.environment import monkey_patch_behave
@@ -13,6 +14,15 @@ from behave_django.runner import (
     ExistingDatabaseTestRunner,
     SimpleTestRunner,
 )
+
+
+def valid_python_module(path):
+    try:
+        module_path, class_name = path.rsplit('.', 1)
+        module = import_module(module_path)
+        return getattr(module, class_name)
+    except (ValueError, AttributeError, ImportError):
+        raise ArgumentTypeError("No module named '{path}' was found.")
 
 
 def add_command_arguments(parser):

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -78,7 +78,7 @@ In your ``.behaverc`` file, you can put
 .. _keepdb docs: https://docs.djangoproject.com/en/stable/topics/testing/overview/#the-test-database
 .. _Django test runner: https://docs.djangoproject.com/en/stable/ref/settings/#test-runner
 .. _Django's default test runner: https://github.com/django/django/blob/stable/4.0.x/django/test/runner.py#L555-L582
-.. |BehaviorDrivenTestRunner| replace:: ``behave_django.runner.BehaviorDrivenTestRunner``
+.. |BehaviorDrivenTestRunner| replace:: ``behave_django.runner:BehaviorDrivenTestRunner``
 .. _BehaviorDrivenTestRunner: https://github.com/behave/behave-django/blob/1.4.0/behave_django/runner.py#L9-L13
 .. _test runner inside behave: https://github.com/behave/behave/blob/v1.2.7.dev2/behave/runner.py#L728-L736
 .. |behave docs (runner opt)| replace:: behave docs

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -22,8 +22,8 @@ recreating it each time you run the test.  This flag enables
 ``manage.py behave --keepdb`` to take advantage of that feature.
 |keepdb docs|_.
 
-``--runner-class``
-******************
+``--runner``
+************
 
 Full Python dotted path to the `Django test runner`_ module used for your
 BDD test suite.  Default: |BehaviorDrivenTestRunner|_
@@ -33,10 +33,10 @@ You can use this option if you require custom behavior that deviates from
 
 .. note::
 
-    Not to be confused with ``--behave-runner-class`` that handles the
-    internal `test runner inside behave`_.  You would use that to override
-    *behave*'s feature/step file discovery and similar behavior.  Read more
-    about it in the |behave docs (runner class)|_.
+    Not to be confused with ``--behave-runner`` that handles the internal
+    `test runner inside behave`_.  You would use that to override *behave*'s
+    feature/step file discovery and similar behavior.  Read more about it
+    in the |behave docs (runner opt)|_.
 
 ``--simple``
 ************
@@ -81,7 +81,7 @@ In your ``.behaverc`` file, you can put
 .. |BehaviorDrivenTestRunner| replace:: ``behave_django.runner.BehaviorDrivenTestRunner``
 .. _BehaviorDrivenTestRunner: https://github.com/behave/behave-django/blob/1.4.0/behave_django/runner.py#L9-L13
 .. _test runner inside behave: https://github.com/behave/behave/blob/v1.2.7.dev2/behave/runner.py#L728-L736
-.. |behave docs (runner class)| replace:: behave docs
-.. _behave docs (runner class): https://behave.readthedocs.io/en/latest/behave.html#cmdoption-runner-class
+.. |behave docs (runner opt)| replace:: behave docs
+.. _behave docs (runner opt): https://behave.readthedocs.io/en/latest/behave.html#cmdoption-r
 .. |behave docs (config files)| replace:: behave docs
 .. _behave docs (config files): https://behave.readthedocs.io/en/latest/behave.html#configuration-files

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 beautifulsoup4
-behave@git+http://github.com/behave/behave.git@v1.2.7.dev2  # behave>=1.2.7
+behave[toml]@git+http://github.com/behave/behave.git@v1.2.7.dev3  # behave>=1.2.7
 django>=3.2

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -31,7 +31,7 @@ class TestCommandLine(DjangoSetupMixin):
             'manage.py', 'behave',
             '--format', 'progress',
             '--behave-runner', 'behave.runner:Runner',
-            '--runner', 'behave_django.runner.BehaviorDrivenTestRunner',
+            '--runner', 'behave_django.runner:BehaviorDrivenTestRunner',
             '--settings', 'test_project.settings',
             '-i', 'some-pattern',
             'features/running-tests.feature'
@@ -121,19 +121,19 @@ class TestCommandLine(DjangoSetupMixin):
 
     @pytest.mark.parametrize('arguments, expect_error', [
         (
-            '--runner behave_django.runner.BehaviorDrivenTestRunner',
+            '--runner behave_django.runner:BehaviorDrivenTestRunner',
             False
         ),
         (
             (
-                '--runner behave_django.runner.SimpleTestRunner '
+                '--runner behave_django.runner:SimpleTestRunner '
                 '--simple'
             ),
             True
         ),
         (
             (
-                '--runner behave_django.runner.BehaviorDrivenTestRunner '
+                '--runner behave_django.runner:BehaviorDrivenTestRunner '
                 '--simple'
             ),
             False
@@ -141,14 +141,14 @@ class TestCommandLine(DjangoSetupMixin):
         (
             (
                 '--behave-runner behave.runner:Runner '
-                '--runner behave_django.runner.SimpleTestRunner '
+                '--runner behave_django.runner:SimpleTestRunner '
                 '--simple'
             ),
             True
         ),
         (
             (
-                '--runner behave_django.runner.SimpleTestRunner '
+                '--runner behave_django.runner:SimpleTestRunner '
                 '--use-existing-database'
             ),
             True
@@ -157,7 +157,7 @@ class TestCommandLine(DjangoSetupMixin):
         (
             (
                 '--behave-runner behave.runner:Runner '
-                '--runner behave_django.runner.BehaviorDrivenTestRunner'
+                '--runner behave_django.runner:BehaviorDrivenTestRunner'
             ),
             False
         ),


### PR DESCRIPTION
- Integrates input validation function for argparse
- Fixes `ArgumentError: argument -r/--runner: conflicting option string: -r`
- Makes `--runner` option require `module:class` syntax (like `--behave-runner`)

Relates to: #147 