### PR TITLE
Explain how to use `coverage run` (docs)

### DIFF
--- a/docs/testcoverage.rst
+++ b/docs/testcoverage.rst
@@ -1,21 +1,50 @@
 Test Coverage
 =============
 
-You can integrate Coverage.py with behave-django to find out the test coverage of your code.
+You can integrate `Coverage.py`_ with behave-django to find out the test coverage
+of your code.
 
-Dependencies
-------------
+There are two ways to do this.  The simple (and obvious one) is via invocation
+through the ``coverage`` CLI.  Alternatively, you can integrate Coverage in the
+``environment.py`` file of your BDD test setup as shown below.
 
-At First, you should install Coverage.py dependency
+Prerequisites
+-------------
+
+Obviously, you need to install Coverage to measure code coverage, e.g.
 
 .. code-block:: bash
 
-    $ pip install coverage
+    $ pip install coverage[toml]
 
-Environment.py
---------------
+Invoke via ``coverage``
+-----------------------
 
-In ``environment.py``, add the code snippet below in the ``before_all`` function to start measuring test coverage:
+Instead of using ``python manage.py``, you simply use
+``coverage run manage.py`` to invoke your BDD tests, e.g.
+
+.. code-block:: bash
+
+    $ coverage run manage.py behave
+
+Afterwards, you can display a coverage report in your terminal to understand
+which lines your tests are missing, e.g.
+
+.. code-block:: bash
+
+    $ coverage report --show-missing
+
+.. tip::
+
+    A Django project setup with coverage configured in ``pyproject.toml`` and
+    executed by Tox is show-cased in the `Painless CI/CD Copier template for
+    Django`_.
+
+Integrate via ``environment.py``
+--------------------------------
+
+In ``environment.py``, add the code snippet below in the ``before_all`` function
+to start measuring test coverage:
 
 .. code-block:: python
 
@@ -37,50 +66,54 @@ You can save the coverage result on html format.
         cov.save()
         cov.html_report(directory="./cov")
 
-
 You can check the test coverage on the web with the following command.
 
 .. code-block:: bash
 
     $ python -m http.server --directory ./cov
-    
-Warning for behave-django
--------------------------
 
-Internally, the time before_all is executed seems to be later than the time when django loads the modules set in each app.
+.. warning::
 
-So sometimes it is necessary to reload django app's modules for accurate test coverage measurement.
+    Internally, the time ``before_all`` is executed seems to be later than the
+    time when django loads the modules set in each app.
 
-Like this:
+    So sometimes it is necessary to reload django app's modules for accurate
+    test coverage measurement.
 
-.. code-block:: python
+    Like this:
 
-    import inspect
-    import importlib
-    
-    def reload_modules():
-      import your_app1
-      import your_app2
+    .. code-block:: python
 
-      for app in [your_app1, your_app2]:
-          members = inspect.getmembers(app)
-          modules = map(
-              lambda keyval: keyval[1],
-              filter(lambda keyval: inspect.ismodule(keyval[1]), members),
-          )
-          for module in modules:
-              try:
-                  importlib.reload(module)
-              except:
-                  continue
+        import inspect
+        import importlib
 
-.. code-block:: python
+        def reload_modules():
+        import your_app1
+        import your_app2
 
-    def before_all(context):
-      # cov
-      cov = coverage.Coverage()
-      cov.start()
-      context.cov = cov
+        for app in [your_app1, your_app2]:
+            members = inspect.getmembers(app)
+            modules = map(
+                lambda keyval: keyval[1],
+                filter(lambda keyval: inspect.ismodule(keyval[1]), members),
+            )
+            for module in modules:
+                try:
+                    importlib.reload(module)
+                except:
+                    continue
 
-      # modules
-      reload_modules()
+    .. code-block:: python
+
+        def before_all(context):
+        # cov
+        cov = coverage.Coverage()
+        cov.start()
+        context.cov = cov
+
+        # modules
+        reload_modules()
+
+.. _Coverage.py: https://coverage.readthedocs.io/
+.. _Painless CI/CD Copier template for Django:
+    https://gitlab.com/painless-software/cicd/app/django


### PR DESCRIPTION
It's possible to measure test coverage by simply invoking the tests using the `coverage` CLI, just naturally as documented in the [Coverage.py docs](https://coverage.readthedocs.io/).

A big, massive thank you to @BillSchumacher for pointing this out! :100: 

Fixes #152