### PR TITLE
Drop obsolete Django 4.1 from test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,14 +27,11 @@ jobs:
         - '3.12'
         django-version:
         - '3.2'
-        - '4.1'
         - '4.2'
         - '5.0'
         exclude:
         - { django-version: '3.2', python-version: '3.11' }
         - { django-version: '3.2', python-version: '3.12' }
-        - { django-version: '4.1', python-version: '3.7' }
-        - { django-version: '4.1', python-version: '3.12' }
         - { django-version: '4.2', python-version: '3.7' }
         - { django-version: '5.0', python-version: '3.7' }
         - { django-version: '5.0', python-version: '3.8' }

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,7 +9,7 @@ Release History
 - Use ruff for linting and code style; reformat code base
 - Migrate packaging from ``setup.py`` to pure ``pyproject.toml``.
 - Add instructions to measure test coverage to the documentation
-- Cover Python 3.9 to 3.12 and Django 3.2, 4.x and 5.0, drop Python 3.5, 3.6 and Django 2.2 and 3.0 support
+- Cover Python 3.9 to 3.12 and Django 3.2, 4.2 and 5.0, drop Python 3.5, 3.6 and Django 2.2 and 3.0 support
 - Bump Behave requirement to 1.2.7.dev3/4/5 (allows TOML support and option to change the Behave TestRunner)
 - New option to change the Django TestRunner
 

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Version Support
 ---------------
 
 *behave-django* is `tested against`_ the officially supported combinations of
-Python and Django (Django 3.2, 4.1, 4.2, 5.0 on Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12).
+Python and Django (Django 3.2, 4.2, 5.0 on Python 3.7 through 3.12).
 
 *behave-django* requires a few newer features of *behave* and hence installs
 a recent unreleased version of `behave`_ as a dependency.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Framework :: Django",
   "Framework :: Django :: 3.2",
-  "Framework :: Django :: 4.1",
   "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.0",
   "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ envlist =
     format
     # Python/Django combinations that are officially supported
     py3{7,8,9,10}-django32
-    py3{8,9,10,11}-django41
     py3{8,9,10,11,12}-django42
     py3{10,11,12}-django50
     behave-latest
@@ -27,7 +26,6 @@ python =
 [gh-actions:env]
 DJANGO =
     3.2: django32
-    4.1: django41
     4.2: django42
     5.0: django50
 
@@ -36,7 +34,6 @@ description = Unit tests
 deps =
     coverage[toml]
     django32: Django>=3.2,<4.0
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<5.0
     django50: Django>=5.0,<5.1
     latest: Django


### PR DESCRIPTION
Let's drop the now-obsolete Django 4.1, as rightfully [suggested](https://github.com/behave/behave-django/pull/155#pullrequestreview-1875915175) by @kingbuzzman.