### PR TITLE
Depend on Behave 1.2.7.dev6+, use Setuptools-SCM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,23 +19,16 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - '3.7'
-        - '3.8'
-        - '3.9'
-        - '3.10'
-        - '3.11'
         - '3.12'
+        - '3.11'
+        - '3.10'
         django-version:
-        - '3.2'
-        - '4.2'
+        - '5.1'
         - '5.0'
-        exclude:
-        - { django-version: '3.2', python-version: '3.11' }
-        - { django-version: '3.2', python-version: '3.12' }
-        - { django-version: '4.2', python-version: '3.7' }
-        - { django-version: '5.0', python-version: '3.7' }
-        - { django-version: '5.0', python-version: '3.8' }
-        - { django-version: '5.0', python-version: '3.9' }
+        - '4.2'
+        include:
+        - { python-version: '3.8', django-version: '4.2' }
+        - { python-version: '3.9', django-version: '4.2' }
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include LICENSE
 include README.rst
 recursive-include behave_django *.py
+prune tests
+prune docs

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Version Support
 ---------------
 
 *behave-django* is `tested against`_ the officially supported combinations of
-Python and Django (Django 3.2, 4.2, 5.0 on Python 3.7 through 3.12).
+Python and Django (Django 4.2, 5.0, 5.1 on Python 3.8 through 3.12).
 
 *behave-django* requires a few newer features of *behave* and hence installs
 a recent unreleased version of `behave`_ as a dependency.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=64"]
+requires = ["setuptools>=64", "setuptools_scm>=8"]
 
 [project]
 name = "behave-django"
@@ -22,15 +22,14 @@ classifiers = [
   "Environment :: Plugins",
   "Environment :: Web Environment",
   "Framework :: Django",
-  "Framework :: Django :: 3.2",
   "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.0",
+  "Framework :: Django :: 5.1",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -46,10 +45,10 @@ keywords = [
   "django",
   "testing",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
-  "behave[toml]@git+http://github.com/behave/behave.git@v1.2.7.dev4",  # behave>=1.2.7.dev3
-  "django>=3.2",
+  "behave[toml]>=1.2.7.dev6",
+  "django>=4.2",
   "beautifulsoup4",
 ]
 
@@ -102,8 +101,8 @@ extend-ignore = ["ANN", "COM812", "D", "FIX", "Q000", "RUF012", "TD"]
 "tests/unit/util.py" = ["S603"]
 "tests/**/*.py" = ["ARG001", "ARG002", "INP001", "PT009", "S101"]
 
-[tool.setuptools.dynamic]
-version = {attr = "behave_django.__version__"}
-
 [tool.setuptools.packages.find]
-namespaces = false
+where = ["."]
+
+[tool.setuptools_scm]
+local_scheme = "no-local-version"

--- a/tox.ini
+++ b/tox.ini
@@ -38,10 +38,10 @@ deps =
     pytest
 commands =
     coverage run -m pytest {posargs}
+    coverage run -a tests/manage.py behave --tags=~@failing --tags=~@requires-live-http --simple {posargs}
+    coverage run -a tests/manage.py behave --tags=~@failing {posargs}
     coverage xml
     coverage report
-    python tests/manage.py behave --tags=~@failing --tags=~@requires-live-http --simple {posargs}
-    python tests/manage.py behave --tags=~@failing {posargs}
 
 [testenv:clean]
 description = Remove Python bytecode and other debris

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,12 @@
 # Tox (https://tox.wiki/) - run tests in isolation using virtualenv.
-# Also contains config settings for tools that don't look into pyproject.toml.
 
 [tox]
 envlist =
     lint
     format
     # Python/Django combinations that are officially supported
-    py3{7,8,9,10}-django32
-    py3{8,9,10,11,12}-django42
-    py3{10,11,12}-django50
+    py3{8,9,10,11,12}-django{42}
+    py3{10,11,12}-django{50,51}
     behave-latest
     package
     docs
@@ -16,7 +14,6 @@ envlist =
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
@@ -25,17 +22,17 @@ python =
 
 [gh-actions:env]
 DJANGO =
-    3.2: django32
     4.2: django42
     5.0: django50
+    5.1: django51
 
 [testenv]
 description = Unit tests
 deps =
     coverage[toml]
-    django32: Django>=3.2,<4.0
     django42: Django>=4.2,<5.0
     django50: Django>=5.0,<5.1
+    django51: Django>=5.1,<5.2
     latest: Django
     latest: git+https://github.com/behave/behave.git#egg=behave
     pytest
@@ -50,8 +47,7 @@ commands =
 description = Remove Python bytecode and other debris
 skip_install = true
 deps = pyclean
-commands =
-    pyclean {posargs:. --debris --erase TESTS-*.xml *-report.xml --yes --verbose}
+commands = pyclean {posargs:. --debris --erase TESTS-*.xml *-report.xml --yes --verbose}
 
 [testenv:docs]
 description = Build package documentation (HTML)


### PR DESCRIPTION
Drops Python 3.7 and Django 3.2, adds Django 5.1 to test matrix.