### PR TITLE
Remediate Django 5.2 breaking change, update test matrix incl. CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install prerequisites
       run: python -m pip install tox
     - name: Run ${{ matrix.env }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install prerequisites
       run: python -m pip install build twine wheel
     - name: Build package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,6 @@ jobs:
         - '5.1'
         - '5.2'
         include:
-        - { python-version: '3.8', django-version: '4.2' }
         - { python-version: '3.9', django-version: '4.2' }
         exclude:
         - { python-version: '3.13', django-version: '4.2' }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,16 +19,21 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - '3.12'
-        - '3.11'
         - '3.10'
+        - '3.11'
+        - '3.12'
+        - '3.13'
         django-version:
-        - '5.1'
-        - '5.0'
         - '4.2'
+        - '5.0'
+        - '5.1'
+        - '5.2'
         include:
         - { python-version: '3.8', django-version: '4.2' }
         - { python-version: '3.9', django-version: '4.2' }
+        exclude:
+        - { python-version: '3.13', django-version: '4.2' }
+        - { python-version: '3.13', django-version: '5.0' }
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
@@ -48,7 +53,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install prerequisites
       run: python -m pip install tox
     - name: Run tests (${{ env.TOXENV }})

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,11 @@ Release History
 
 - Cover Python 3.13 and Django 5.2, drop Python 3.8 (pyproject license field change requires setuptools 77)
 
+**Bugfixes**
+
+- Remediate Django 5.2 TestCase breaking change (TestCase classmethods)
+- Fix test for Python 3.13 breaking change (argparse CLI output)
+
 1.5.0 (2024-10-03)
 ++++++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,14 @@
 Release History
 ---------------
 
-1.5.0 (unreleased)
+1.6.0 (unreleased)
+++++++++++++++++++
+
+**Features and Improvements**
+
+- Cover Python 3.13 and Django 5.2, drop Python 3.8 (pyproject license field change requires setuptools 77)
+
+1.5.0 (2024-10-03)
 ++++++++++++++++++
 
 **Features and Improvements**
@@ -10,7 +17,7 @@ Release History
 - Migrate packaging from ``setup.py`` to pure ``pyproject.toml``.
 - Add instructions to measure test coverage to the documentation
 - Cover Python 3.9 to 3.12 and Django 3.2, 4.2 and 5.0, drop Python 3.5, 3.6 and Django 2.2 and 3.0 support
-- Bump Behave requirement to 1.2.7.dev3/4/5 (allows TOML support and option to change the Behave TestRunner)
+- Bump Behave requirement to 1.2.7.dev6 (allows TOML support and option to change the Behave TestRunner)
 - New option to change the Django TestRunner
 
 1.4.0 (2020-06-15)

--- a/behave_django/testcase.py
+++ b/behave_django/testcase.py
@@ -1,18 +1,19 @@
+import django
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.test.testcases import TestCase
 
 
-class BehaviorDrivenTestMixin:
+class PreventTestSetupMixin:
     """Prevents the TestCase from executing its setup and teardown methods.
 
     This mixin overrides the test case's ``_pre_setup`` and ``_post_teardown``
     methods in order to prevent them from executing when the test case is
     instantiated.  We do this to have total control over the test execution.
-    """
 
-    def _pre_setup(self, run=False):
-        if run:
-            super()._pre_setup()
+    Django 5.2 changed ``_pre_setup`` and ``_fixture_setup`` to classmethods,
+    hence the conditional handling below.
+    See https://github.com/django/django/commit/8eca3e9b
+    """
 
     def _post_teardown(self, run=False):
         if run:
@@ -22,6 +23,31 @@ class BehaviorDrivenTestMixin:
         pass
 
 
+if django.VERSION < (5, 2):
+
+    class BehaviorDrivenTestMixin(PreventTestSetupMixin):
+        def _pre_setup(self, run=False):
+            if run:
+                super()._pre_setup()
+
+    class PreventFixturesMixin:
+        def _fixture_setup(self):
+            pass
+
+else:  # Django 5.2 introduced some classmethods
+
+    class BehaviorDrivenTestMixin(PreventTestSetupMixin):
+        @classmethod
+        def _pre_setup(cls, run=False):
+            if run:
+                super()._pre_setup()
+
+    class PreventFixturesMixin:
+        @classmethod
+        def _fixture_setup(cls):
+            pass
+
+
 class BehaviorDrivenTestCase(BehaviorDrivenTestMixin, StaticLiveServerTestCase):
     """Test case attached to the context during behave execution.
 
@@ -29,14 +55,11 @@ class BehaviorDrivenTestCase(BehaviorDrivenTestMixin, StaticLiveServerTestCase):
     """
 
 
-class ExistingDatabaseTestCase(BehaviorDrivenTestCase):
+class ExistingDatabaseTestCase(PreventFixturesMixin, BehaviorDrivenTestCase):
     """Test case used for the --use-existing-database setup.
 
     This test case prevents fixtures from being loaded to the database in use.
     """
-
-    def _fixture_setup(self):
-        pass
 
     def _fixture_teardown(self):
         pass

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -20,6 +20,12 @@ generate the docs:
 
     $ pip install tox
 
+If you use uv, install Tox with the tox-uv plugin:
+
+.. code:: console
+
+    $ uv tool install tox --with tox-uv
+
 Essentials
 ----------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=64", "setuptools_scm>=8"]
+requires = ["setuptools>=77", "setuptools_scm>=8"]
 
 [project]
 name = "behave-django"
 dynamic = ["version"]
 description = "Behave BDD integration for Django"
 readme = "README.rst"
-license = {file = "LICENSE"}
+license = "MIT"
 authors = [
   {name = "Mitchel Cabuloy", email = "mixxorz@gmail.com"},
   {name = "Peter Bittner", email = "django@bittner.it"},
@@ -25,16 +25,16 @@ classifiers = [
   "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.0",
   "Framework :: Django :: 5.1",
+  "Framework :: Django :: 5.2",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Internet :: WWW/HTTP",
   "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
   "Topic :: Software Development :: Testing",
@@ -45,7 +45,7 @@ keywords = [
   "django",
   "testing",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
   "behave[toml]>=1.2.7.dev6",
   "django>=4.2",
@@ -73,9 +73,7 @@ show_missing = true
 
 [tool.pytest.ini_options]
 addopts = "--color=yes --junitxml=tests/unittests-report.xml --verbose"
-testpaths = [
-    "tests/unit",
-]
+testpaths = ["tests/unit"]
 
 [tool.ruff]
 extend-exclude = ["docs/conf.py"]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,5 +1,6 @@
 import os
 from importlib import reload
+from sys import version_info
 
 import pytest
 
@@ -8,6 +9,13 @@ from .util import DjangoSetupMixin, run_silently, show_run_error
 
 class TestCommandLine(DjangoSetupMixin):
     def test_additional_management_command_options(self):
+        runner_class_option = (
+            # Python 3.13 consolidates arguments, see gh-101599 in changelog
+            '  --behave-r RUNNER_CLASS, --behave-runner RUNNER_CLASS'
+            if version_info < (3, 13)
+            else '  --behave-r, --behave-runner RUNNER_CLASS'
+        )
+
         exit_status, output = run_silently('python tests/manage.py behave --help')
 
         assert exit_status == 0, show_run_error(exit_status, output)
@@ -15,9 +23,7 @@ class TestCommandLine(DjangoSetupMixin):
         assert (os.linesep + '  -k, --keepdb') in output
         assert (os.linesep + '  -S, --simple') in output
         assert (os.linesep + '  --runner ') in output
-        assert (
-            os.linesep + '  --behave-r RUNNER_CLASS, --behave-runner RUNNER_CLASS'
-        ) in output
+        assert (os.linesep + runner_class_option) in output
         assert (os.linesep + '  --noinput, --no-input') in output
         assert (os.linesep + '  --failfast') in output
         assert (os.linesep + '  -r, --reverse') in output

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,8 @@ envlist =
     format
     # Python/Django combinations that are officially supported
     py3{8,9,10,11,12}-django{42}
-    py3{10,11,12}-django{50,51}
+    py3{10,11,12}-django{50}
+    py3{10,11,12,13}-django{51,52}
     behave-latest
     package
     docs
@@ -19,12 +20,14 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [gh-actions:env]
 DJANGO =
     4.2: django42
     5.0: django50
     5.1: django51
+    5.2: django52
 
 [testenv]
 description = Unit tests
@@ -33,6 +36,7 @@ deps =
     django42: Django>=4.2,<5.0
     django50: Django>=5.0,<5.1
     django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<6.0
     latest: Django
     latest: git+https://github.com/behave/behave.git#egg=behave
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     lint
     format
     # Python/Django combinations that are officially supported
-    py3{8,9,10,11,12}-django{42}
+    py3{9,10,11,12}-django{42}
     py3{10,11,12}-django{50}
     py3{10,11,12,13}-django{51,52}
     behave-latest
@@ -15,7 +15,6 @@ envlist =
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311


### PR DESCRIPTION
Adds Python 3.13 and Django 5.2 to the test matrix. Still keeps Django 5.0 included for our users' convenience.

Note that we must drop the end-of-life Python 3.8 to honor the changed semantics of the [pyproject license field](https://packaging.python.org/en/latest/guides/licensing-examples-and-user-scenarios/), which affects Django 4.2 users. They can continue using behave-django 1.5.0, though.

Fixes #161 