### PR TITLE
Avoid Behave v1.2.7.dev7 (ModuleNotFoundError: 'six')

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ keywords = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-  "behave[toml]>=1.2.7.dev6",
+  "behave[toml]>=1.2.7.dev6,!=1.2.7.dev7",
   "django>=4.2",
   "beautifulsoup4",
 ]


### PR DESCRIPTION
Excludes the recent Behave pre-release as a dependency, which causes dependency issues when installed using Pip.

## See also

- https://github.com/behave/behave/issues/1251
- [Latest failing tests](https://github.com/behave/behave-django/actions/runs/16330027352) (`ModuleNotFoundError: No module named 'six'`)