### PR TITLE
chore: update dep behave to 1.2.7.dev8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ keywords = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-  "behave[toml]==1.2.7.dev6",
+  "behave[toml]==1.2.7.dev8",
   "django>=4.2",
   "beautifulsoup4",
 ]


### PR DESCRIPTION
There is newer version 1.3.1, too. But this shouldn't change too much. But it will fix some async running problems I am facing.

It complains that WARNING: behave 1.2.7.dev8 does not provide the extra 'toml'. Is it required for what?