### PR TITLE
Fix RecursionError on Django 4.1+ when running without --simple

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,15 @@
 Release History
 ---------------
 
+(unreleased)
+++++++++++++
+
+**Bugfixes**
+
+- Fix ``RecursionError`` on Django 4.1+ without ``--simple``: call
+  ``doClassCleanups()`` after ``tearDownClass()`` to prevent settings
+  overrides from accumulating across scenarios.
+
 1.9.0 (2025-11-15)
 ++++++++++++++++++
 

--- a/behave_django/environment.py
+++ b/behave_django/environment.py
@@ -107,6 +107,7 @@ class BehaveHooksMixin:
     def teardown_test(self, context):
         """Tear down the Django test."""
         context.test.tearDownClass()
+        context.test.__class__.doClassCleanups()  # needed for Django 4.1+
         context.test._post_teardown(run=True)
         del context.test
 

--- a/tests/acceptance/features/class-cleanups.feature
+++ b/tests/acceptance/features/class-cleanups.feature
@@ -1,0 +1,17 @@
+@requires-live-http
+Feature: Settings overrides do not accumulate across scenarios
+    In order to run my tests without issues
+    As a behave-django developer
+    I want to avoid RecursionError when running many scenarios
+    So that my test suite does not crash regardless of its size
+
+    Scenario Outline: Scenario <n> completes without RecursionError
+        Then a Django setting can be accessed with a recursion headroom of 5
+
+    Examples:
+        | n |
+        | 1 |
+        | 2 |
+        | 3 |
+        | 4 |
+        | 5 |

--- a/tests/acceptance/steps/class_cleanups.py
+++ b/tests/acceptance/steps/class_cleanups.py
@@ -1,0 +1,17 @@
+import sys
+import traceback
+
+from behave import then
+from django.conf import settings
+
+
+@then('a Django setting can be accessed with a recursion headroom of {headroom:d}')
+def access_django_setting(context, headroom):
+    depth = len(traceback.extract_stack())
+    settings.__dict__.pop('DEBUG', None)
+    old_limit = sys.getrecursionlimit()
+    sys.setrecursionlimit(depth + headroom)
+    try:
+        _ = settings.DEBUG
+    finally:
+        sys.setrecursionlimit(old_limit)


### PR DESCRIPTION
## Problem

When running behave-django **without** `--simple` on Django 4.1+, a `RecursionError` eventually occurs after roughly 1000 scenarios:

```
File "django/conf/__init__.py", line 331, in __getattr__
  return getattr(self.default_settings, name)
  [Previous line repeated 965 more times]
RecursionError: maximum recursion depth exceeded
```

Fixes #164.

### Root cause

Django 4.1 changed `LiveServerTestCase.setUpClass()` to register its `modify_settings` cleanup via `addClassCleanup()` instead of an explicit `tearDownClass()` override:

```python
# Django 4.1+ LiveServerTestCase.setUpClass():
cls._live_server_modified_settings.enable()
cls.addClassCleanup(cls._live_server_modified_settings.disable)  # <-- new
```

In standard `unittest` usage, the test runner calls `doClassCleanups()` after `tearDownClass()`. Because behave-django drives `setUpClass`/`tearDownClass` **per scenario** rather than through `unittest.TestSuite`, `doClassCleanups()` was never invoked.

This means `_live_server_modified_settings.disable()` is never called between scenarios. Each scenario pushes a new `UserSettingsHolder` (a Django internal class) wrapping `ALLOWED_HOSTS` onto `settings._wrapped` without ever popping it. After ~1000 scenarios, resolving any Django setting traverses a 1000-deep chain of `UserSettingsHolder` objects, exceeding Python's recursion limit.

### Fix

Call `doClassCleanups()` explicitly in `teardown_test()`, replicating the full class lifecycle that `unittest.TestSuite` normally provides:

```python
def teardown_test(self, context):
    context.test.tearDownClass()
    context.test.__class__.doClassCleanups()  # <-- added
    context.test._post_teardown(run=True)
    del context.test
```

### Affected versions

Django ≤ 4.0 is not affected because `tearDownClass()` called `disable()` explicitly. Django 4.1+ is affected.