### PR TITLE
Update test matrix to Django 5.2 and 6.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       with:
-        python-version: '3.13'
+        python-version: '3.14'
     - name: Install prerequisites
       run: python -m pip install tox
     - name: Run ${{ matrix.env }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       with:
-        python-version: '3.13'
+        python-version: '3.14'
     - name: Install prerequisites
       run: python -m pip install build twine wheel
     - name: Build package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,17 +23,13 @@ jobs:
         - '3.11'
         - '3.12'
         - '3.13'
+        - '3.14'
         django-version:
-        - '4.2'
-        - '5.0'
-        - '5.1'
         - '5.2'
-        include:
-        - { python-version: '3.9', django-version: '4.2' }
-        - { python-version: '3.14', django-version: '5.2' }
+        - '6.0'
         exclude:
-        - { python-version: '3.13', django-version: '4.2' }
-        - { python-version: '3.13', django-version: '5.0' }
+        - { python-version: '3.10', django-version: '6.0' }
+        - { python-version: '3.11', django-version: '6.0' }
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
@@ -53,7 +49,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       with:
-        python-version: '3.13'
+        python-version: '3.14'
     - name: Install prerequisites
       run: python -m pip install tox
     - name: Run tests (${{ env.TOXENV }})

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Version Support
 ---------------
 
 *behave-django* is `tested against`_ the officially supported combinations of
-Python and Django (Django 4.2, 5.0, 5.1, 5.2 on Python 3.9 through 3.14).
+Python and Django (Django 5.2, 6.0 on Python 3.10 through 3.14).
 
 Installs the latest stable version of `behave`_ as a dependency.
 

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -44,7 +44,7 @@ section in ``tox.ini`` for details.
 .. code:: console
 
     $ tox list               # show all Tox environments
-    $ tox -e py314-django52  # run just a single environment
+    $ tox -e py314-django60  # run just a single environment
     $ tox                    # run all linting and tests
 
 Getting your hands dirty

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,15 +22,12 @@ classifiers = [
   "Environment :: Plugins",
   "Environment :: Web Environment",
   "Framework :: Django",
-  "Framework :: Django :: 4.2",
-  "Framework :: Django :: 5.0",
-  "Framework :: Django :: 5.1",
   "Framework :: Django :: 5.2",
+  "Framework :: Django :: 6.0",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -46,10 +43,10 @@ keywords = [
   "django",
   "testing",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
   "behave>=1.3.3",
-  "django>=4.2",
+  "django>=5.2",
   "beautifulsoup4",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,8 @@ envlist =
     lint
     format
     # Python/Django combinations that are officially supported
-    py3{9,10,11,12}-django{42}
-    py3{10,11,12}-django{50}
-    py3{10,11,12,13}-django{51}
-    py3{10,11,12,13,14}-django{52}
+    py3{10,11}-django{52}
+    py3{12,13,14}-django{52,60}
     behave-latest
     package
     docs
@@ -16,7 +14,6 @@ envlist =
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
@@ -25,19 +22,15 @@ python =
 
 [gh-actions:env]
 DJANGO =
-    4.2: django42
-    5.0: django50
-    5.1: django51
     5.2: django52
+    6.0: django60
 
 [testenv]
 description = Unit tests
 deps =
     coverage[toml]
-    django42: Django>=4.2,<5.0
-    django50: Django>=5.0,<5.1
-    django51: Django>=5.1,<5.2
     django52: Django>=5.2,<6.0
+    django60: Django>=6.0,<6.1
     latest: Django
     latest: git+https://github.com/behave/behave.git#egg=behave
     pytest


### PR DESCRIPTION
Drop Django 4.2/5.0/5.1 (no longer officially supported) and add Django 6.0.

Adjust Python versions per Django's official support: Django 5.2+ on Python 3.10-3.14, Django 6.0+ on Python 3.12-3.14.