### PR TITLE
Auto-isolate `context.fixtures` per behave scope (#179)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,15 @@ Release History
 (unreleased)
 ++++++++++++
 
+**Breaking Changes**
+
+- ``context.fixtures`` is now snapshotted onto every scope behave pushes
+  (feature, rule, scenario), so mutations made inside a scope no longer
+  leak into sibling scopes.  Values set in ``before_all()``,
+  ``before_feature()`` or ``before_rule()`` still propagate inward as a
+  baseline; the manual reset recipe (``context.fixtures = []`` after
+  each scenario or feature) is no longer needed (#179).
+
 **Bugfixes**
 
 - Fix ``RecursionError`` on Django 4.1+ without ``--simple``: call

--- a/behave_django/environment.py
+++ b/behave_django/environment.py
@@ -121,24 +121,46 @@ def monkey_patch_behave(django_test_runner):
 
     def load_hooks(self, filename=None):
         """
-        Load hooks and ensure before_scenario/after_scenario are registered.
+        Load hooks and ensure scope hooks are registered.
 
         Behave v1.3+ doesn't call run hooks that aren't defined, so we must
-        do this explicitly to make sure we're called in any case.
+        do this explicitly to make sure we're called in any case (for the
+        ``before_feature`` / ``before_rule`` snapshot and the
+        ``before_scenario`` / ``after_scenario`` Django test setup).
         """
         behave_load_hooks(self, filename)
 
-        if 'before_scenario' not in self.hooks:
-            self.hooks['before_scenario'] = lambda *_: None
-
-        if 'after_scenario' not in self.hooks:
-            self.hooks['after_scenario'] = lambda *_: None
+        for hook_name in (
+            'before_feature',
+            'before_rule',
+            'before_scenario',
+            'after_scenario',
+        ):
+            if hook_name not in self.hooks:
+                self.hooks[hook_name] = lambda *_: None
 
     def run_hook(self, hook_name, *args):
         context = self.context
 
         if hook_name == 'before_all':
             django_test_runner.patch_context(context)
+
+        if hook_name in (
+            'before_all',
+            'before_feature',
+            'before_rule',
+            'before_scenario',
+        ):
+            # Snapshot any fixture configuration set in a higher scope onto
+            # the current behave layer (test run / feature / rule / scenario).
+            # This confines mutations to the scope where they happen — both
+            # assignment (``context.fixtures = [...]``) and in-place edits
+            # (``context.fixtures.append(...)``) — so they are discarded
+            # when behave pops the layer and never bleed into a sibling
+            # feature, rule, or scenario.  Snapshotting on ``before_all``
+            # also lets users call ``context.fixtures.append(...)`` there
+            # without first assigning a list.
+            context.fixtures = list(getattr(context, 'fixtures', []))
 
         behave_run_hook(self, hook_name, *args)
 

--- a/docs/fixtures.rst
+++ b/docs/fixtures.rst
@@ -1,7 +1,7 @@
 Fixture Loading
 ===============
 
-behave-django can load your fixtures for you per feature/scenario. There are
+behave-django can load your fixtures for you per scenario. There are
 two approaches to this:
 
 * loading the fixtures in ``environment.py``, or
@@ -11,16 +11,39 @@ two approaches to this:
 Fixtures in environment.py
 --------------------------
 
-In ``environment.py`` we can load our context with the fixtures array.
+You configure fixtures by populating ``context.fixtures`` from one of
+behave's hooks (``before_all``, ``before_feature``, ``before_rule`` or
+``before_scenario``).  behave-django takes a **fresh copy** of
+``context.fixtures`` when each scope starts, so anything you do inside
+that scope — whether you assign (``context.fixtures = [...]``) or mutate
+in place (``context.fixtures.append(...)``) — is confined to that scope
+and is automatically discarded when behave leaves it.
+
+This means:
+
+* Values set in an outer scope (e.g. ``before_all``) flow into inner
+  scopes as a baseline.
+* Mutations in an inner scope (e.g. ``before_scenario``) never leak back
+  out to the outer scope or sideways into sibling scopes.
+* You never need to "reset" ``context.fixtures`` manually between
+  scenarios or features.
+
+Loading the same fixtures for every scenario:
 
 .. code-block:: python
 
     def before_all(context):
         context.fixtures = ['user-data.json']
 
-This fixture would then be loaded before every scenario.
+Loading fixtures for an entire feature:
 
-If you wanted different fixtures for different scenarios:
+.. code-block:: python
+
+    def before_feature(context, feature):
+        if feature.name == 'Login':
+            context.fixtures = ['user-data.json']
+
+Loading or extending fixtures for individual scenarios:
 
 .. code-block:: python
 
@@ -29,38 +52,40 @@ If you wanted different fixtures for different scenarios:
             context.fixtures = ['user-data.json']
         elif scenario.name == 'Check out cart':
             context.fixtures = ['user-data.json', 'store.json', 'cart.json']
-        else:
-            # Resetting fixtures, otherwise previously set fixtures carry
-            # over to subsequent scenarios.
-            context.fixtures = []
 
-You could also have fixtures per Feature too
+Combining a feature-wide baseline with scenario-specific extras:
 
 .. code-block:: python
 
     def before_feature(context, feature):
-        if feature.name == 'Login':
+        if feature.name == 'Shopping':
             context.fixtures = ['user-data.json']
-            # This works because behave will use the same context for
-            # everything below Feature. (Scenarios, Outlines, Backgrounds)
-        else:
-            # Resetting fixtures, otherwise previously set fixtures carry
-            # over to subsequent features.
+
+    def before_scenario(context, scenario):
+        if scenario.name == 'Check out cart':
+            context.fixtures.append('cart.json')
+
+In the example above, the "Shopping" feature's other scenarios still
+receive only ``user-data.json`` — the ``cart.json`` append affects only
+the "Check out cart" scenario.  Other features are not affected at all.
+
+Opting out of inherited fixtures
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To run a scenario (or a whole feature) without the fixtures inherited
+from a parent scope, assign an empty list:
+
+.. code-block:: python
+
+    def before_all(context):
+        context.fixtures = ['user-data.json']
+
+    def before_scenario(context, scenario):
+        if scenario.name == 'Anonymous visitor':
             context.fixtures = []
 
-Of course, since ``context.fixtures`` is really just a list, you can mutate it
-however you want, it will only be processed upon leaving the
-``before_scenario()`` function of your ``environment.py`` file. Just keep in
-mind that it does not reset between features or scenarios, unless explicitly
-done so (as shown in the examples above).
-
-.. attention::
-
-    Starting with **behave-django 2.0.0**, the ``context.fixtures`` attribute
-    will be automatically reset after each scenario. This means you will no
-    longer need to explicitly set ``context.fixtures = []`` to reset fixtures
-    between scenarios or features. The automatic reset will make fixture
-    handling more user-friendly and less error-prone.
+The "Anonymous visitor" scenario runs without any fixtures; every other
+scenario still receives ``user-data.json`` from ``before_all``.
 
 .. note::
 

--- a/tests/acceptance/environment.py
+++ b/tests/acceptance/environment.py
@@ -4,21 +4,27 @@ behave environment module for testing behave-django
 
 
 def before_feature(context, feature):
+    """Using ``append()`` here also verifies that mutations in
+    ``before_feature`` are confined to the current feature and do not
+    leak into the next one.
+    """
     if feature.name == 'Fixture loading':
-        context.fixtures = ['behave-fixtures.json']
+        context.fixtures.append('behave-fixtures.json')
 
     elif feature.name == 'Fixture loading with decorator':
         # Including empty fixture to test that #92 is fixed
-        context.fixtures = ['empty-fixture.json']
-
-    elif feature.name == 'Fixture reset - first feature with fixtures':
-        context.fixtures = ['behave-fixtures.json']
-
-    elif feature.name == 'Fixture reset - second feature with empty fixtures':
-        context.fixtures = []
+        context.fixtures.append('empty-fixture.json')
 
 
 def before_scenario(context, scenario):
+    if (
+        scenario.feature.name == 'Fixture auto-reset across scenarios'
+        and scenario.name == 'First scenario loads a fixture'
+    ):
+        # Other scenarios in this feature deliberately leave
+        # context.fixtures empty to verify the auto-reset behaviour.
+        context.fixtures.append('behave-fixtures.json')
+
     if scenario.name == 'Load fixtures for this scenario and feature':
         context.fixtures.append('behave-second-fixture.json')
 
@@ -28,6 +34,10 @@ def before_scenario(context, scenario):
 
     if scenario.name == 'Load fixtures with databases option':
         context.databases = '__all__'
+
+    if scenario.name == 'Override inherited fixtures with empty list':
+        # Suppress the fixture inherited from ``before_feature``.
+        context.fixtures = []
 
 
 def django_ready(context):

--- a/tests/acceptance/features/fixture-auto-reset.feature
+++ b/tests/acceptance/features/fixture-auto-reset.feature
@@ -1,0 +1,14 @@
+@requires-live-http
+Feature: Fixture auto-reset across scenarios
+    In order to write independent scenarios without manual cleanup
+    As a developer
+    I want context.fixtures to be reset automatically between scenarios
+
+    Scenario: First scenario loads a fixture
+        Then the fixture should be loaded
+
+    Scenario: Second scenario inherits no fixtures
+        Then there should be no fixtures loaded
+
+    Scenario: Third scenario also inherits no fixtures
+        Then there should be no fixtures loaded

--- a/tests/acceptance/features/fixture-loading.feature
+++ b/tests/acceptance/features/fixture-loading.feature
@@ -16,3 +16,6 @@ Feature: Fixture loading
 
     Scenario: Load fixtures with databases option
         Then databases should be set to all database in the Django settings
+
+    Scenario: Override inherited fixtures with empty list
+        Then there should be no fixtures loaded

--- a/tests/acceptance/features/fixture-reset-first.feature
+++ b/tests/acceptance/features/fixture-reset-first.feature
@@ -1,8 +1,0 @@
-@requires-live-http
-Feature: Fixture reset - first feature with fixtures
-    In order to test fixture reset between features
-    As a developer
-    I want to load fixtures in the first feature
-
-    Scenario: First feature loads fixtures
-        Then the fixture should be loaded

--- a/tests/acceptance/features/fixture-reset-second.feature
+++ b/tests/acceptance/features/fixture-reset-second.feature
@@ -1,8 +1,0 @@
-@requires-live-http
-Feature: Fixture reset - second feature with empty fixtures
-    In order to test fixture reset between features
-    As a developer
-    I want fixtures to be properly reset when set to empty list in before_feature
-
-    Scenario: Second feature should have no fixtures
-        Then there should be no fixtures loaded


### PR DESCRIPTION
Snapshot `context.fixtures` onto every behave layer (feature, rule, scenario) so mutations made inside a scope stay confined to that scope and are discarded when behave pops the layer. Values set in `before_all` / `before_feature` / `before_rule` still propagate inward as a baseline; users no longer need to reset `context.fixtures = []` between scenarios or features.

Register no-op `before_feature` and `before_rule` hooks so behave's "skip hooks that aren't defined" short-circuit doesn't bypass the snapshot.

Drop the old "fixture reset" features (they tested the obsolete manual reset recipe). Add `fixture-auto-reset.feature` to verify scenarios don't inherit a sibling scenario's fixtures, switch the fixture-loading `before_feature` to use `append()` (verifies the feature-level snapshot), and add an "Override inherited fixtures with empty list" scenario that confirms `context.fixtures = []` in `before_scenario` suppresses a fixture inherited from `before_feature`.

Resolves #179 