### PR TITLE
Document custom LiveServerTestCase host for remote browsers

### DIFF
--- a/docs/webbrowser.rst
+++ b/docs/webbrowser.rst
@@ -30,4 +30,67 @@ Examples:
     context.get_url(model_instance)
 
 
+Remote browsers and Selenium Hub
+--------------------------------
+
+By default the live test server binds to ``localhost``, which is fine when
+the browser runs on the same machine as the tests.  If your browser runs in
+a separate container or on a different host (for example, behind a
+`Selenium Grid`_ hub), the server needs to listen on an address the browser
+can reach.
+
+Django exposes ``host`` and ``port`` as class attributes on
+``LiveServerTestCase``, and uses the same ``host`` both to bind the socket
+and to build ``live_server_url`` (which is what ``context.get_url()``
+returns).  Pick a hostname the remote browser can resolve — for example,
+the docker-compose service name of the Django container — rather than
+``0.0.0.0``, which would leak into the URL handed to the browser.  Then
+pair the subclass with a custom test runner and select it via the
+|--runner|_ option:
+
+.. code-block:: python
+
+    # myproject/runner.py
+    from behave_django.runner import BehaviorDrivenTestRunner
+    from behave_django.testcase import BehaviorDrivenTestCase
+
+
+    class RemoteBrowserTestCase(BehaviorDrivenTestCase):
+        # Must be resolvable from the browser container.
+        # In docker-compose this is typically the service name.
+        host = 'myapp'
+        port = 8100
+
+
+    class RemoteBrowserTestRunner(BehaviorDrivenTestRunner):
+        testcase_class = RemoteBrowserTestCase
+
+.. code-block:: console
+
+    $ python manage.py behave --runner myproject.runner.RemoteBrowserTestRunner
+
+In your step setup you can then connect to a remote WebDriver and visit
+``context.get_url()`` as usual — the URL will resolve to the address your
+browser container can reach:
+
+.. code-block:: python
+
+    # features/environment.py
+    from splinter.browser import Browser
+
+    def before_all(context):
+        context.browser = Browser(
+            driver_name='remote',
+            browser='chrome',
+            command_executor='http://selenium-hub:4444/wd/hub',
+        )
+
+Make sure the chosen host is listed in ``ALLOWED_HOSTS`` (or set
+``ALLOWED_HOSTS = ['*']`` in a test-only settings module), so Django accepts
+the incoming requests.
+
+
 .. _django.shortcuts.redirect: https://docs.djangoproject.com/en/stable/topics/http/shortcuts/#redirect
+.. _Selenium Grid: https://www.selenium.dev/documentation/grid/
+.. |--runner| replace:: ``--runner``
+.. _--runner: configuration.html#runner


### PR DESCRIPTION
## Summary
- Adds a "Remote browsers and Selenium Hub" section to `docs/webbrowser.rst` showing how to subclass `BehaviorDrivenTestCase` with a custom `host` / `port` and select it via the `--runner` option.
- Covers the use case from #124: driving the live server from a Selenium Hub (or any browser running in a separate container / on a different host).
- Includes a worked `splinter` example pointing at `http://selenium-hub:4444/wd/hub` and a note about `ALLOWED_HOSTS`.

No code changes — the pattern already works with the existing extension points (`testcase_class` on a runner subclass + Django's `LiveServerTestCase.host` / `.port`). This PR just makes that discoverable so #124 can be closed with a pointer to the docs.

## Test plan
- [x] `tox -e docs` builds without warnings
- [x] Rendered HTML spot-checked: section appears in the TOC and the `--runner` cross-link resolves to `configuration.html#runner`