### PR TITLE
Fix double base_url in get_url() for absolute URLs

### DIFF
--- a/behave_django/environment.py
+++ b/behave_django/environment.py
@@ -1,4 +1,5 @@
 from copy import copy
+from urllib.parse import urlparse
 
 import django
 from behave.runner import Context, ModelRunner, Runner
@@ -20,7 +21,22 @@ class PatchedContext(Context):
             raise RuntimeError(msg) from err
 
     def get_url(self, to=None, *args, **kwargs):
-        return self.base_url + (resolve_url(to, *args, **kwargs) if to else '')
+        """Build a URL for the live test server.
+
+        Without an argument (or with a falsy ``to``), return ``base_url``.
+        Otherwise resolve ``to`` via Django's ``resolve_url`` shortcut and
+        prepend ``base_url``.  If the resolved value is already absolute
+        (e.g. a model's ``get_absolute_url()`` returning a full URL, or
+        ``to`` being a full URL string), it is returned as-is to avoid
+        producing a malformed double-host string like
+        ``"http://localhost:8000http://example.com/"``.
+        """
+        if not to:
+            return self.base_url
+        url = resolve_url(to, *args, **kwargs)
+        if urlparse(url).scheme:
+            return url
+        return self.base_url + url
 
 
 def load_registered_fixtures(context):

--- a/tests/acceptance/features/context-urlhelper.feature
+++ b/tests/acceptance/features/context-urlhelper.feature
@@ -8,6 +8,10 @@ Feature: URL helpers are available in behave's context
         When I call get_url() without arguments
         Then it returns the value of base_url
 
+    Scenario: get_url("") with an empty string also returns base_url
+        When I call get_url("") with an empty string
+        Then it returns the value of base_url
+
     Scenario: The first argument in get_url() is appended to base_url if it is a path
         When I call get_url("/path/to/page/") with an absolute path
         Then the result is the base_url with "/path/to/page/" appended
@@ -21,3 +25,11 @@ Feature: URL helpers are available in behave's context
         When I call get_url(model) with a model instance
         Then this returns the same result as get_url(model.get_absolute_url())
         And the result is the base_url with model.get_absolute_url() appended
+
+    Scenario: A full URL passed to get_url() is returned as-is, not concatenated to base_url
+        When I call get_url("https://example.com/foo") with a full URL
+        Then the result is "https://example.com/foo"
+
+    Scenario: A model whose get_absolute_url() returns a full URL is not concatenated to base_url
+        When I call get_url(model) with a model whose get_absolute_url returns "https://example.com/bar"
+        Then the result is "https://example.com/bar"

--- a/tests/acceptance/steps/context-urlhelper.py
+++ b/tests/acceptance/steps/context-urlhelper.py
@@ -8,6 +8,11 @@ def without_args(context):
     context.result = context.get_url()
 
 
+@when('I call get_url("") with an empty string')
+def empty_string_arg(context):
+    context.result = context.get_url('')
+
+
 @when('I call get_url("{url_path}") with an absolute path')
 def path_arg(context, url_path):
     context.result = context.get_url(url_path)
@@ -22,6 +27,25 @@ def view_arg(context, view_name):
 def model_arg(context):
     context.model = BehaveTestModel(name='Foo', number=3)
     context.result = context.get_url(context.model)
+
+
+@when('I call get_url("{url}") with a full URL')
+def full_url_arg(context, url):
+    context.result = context.get_url(url)
+
+
+@when('I call get_url(model) with a model whose get_absolute_url returns "{url}"')
+def model_full_url_arg(context, url):
+    class _FullUrlModel:
+        def get_absolute_url(self):
+            return url
+
+    context.result = context.get_url(_FullUrlModel())
+
+
+@then('the result is "{expected}"')
+def result_equals(context, expected):
+    context.test.assertEqual(context.result, expected)
 
 
 @then('it returns the value of base_url')


### PR DESCRIPTION
## Summary

- `PatchedContext.get_url()` blindly prepended `base_url` to whatever `resolve_url()` returned. When the resolved value was already an absolute URL — either because `to` was a full URL string, or because a model's `get_absolute_url()` returns one — the result was malformed: `http://localhost:8000http://example.com/foo`.
- Now we inspect the resolved URL with `urllib.parse.urlparse` and skip the prefix when a scheme is present.

Closes #141 (the `**kwargs`/Pylint sub-tasks in that issue are no longer load-bearing: `to` is a named parameter so it cannot leak into `**kwargs`, and the project moved from Pylint to Ruff).

## Test plan

- [x] `tests/acceptance/features/context-urlhelper.feature` — two new scenarios cover (a) a full URL passed as `to` and (b) a model whose `get_absolute_url()` returns a full URL.
- [x] `tests/manage.py behave --tags=~@failing` — 31 scenarios pass, 0 fail.
- [x] `ruff check` and `ruff format --check` clean.