### PR TITLE
Snapshot context.fixtures in user mode to avoid ContextMaskWarning

### DIFF
--- a/behave_django/environment.py
+++ b/behave_django/environment.py
@@ -176,7 +176,11 @@ def monkey_patch_behave(django_test_runner):
             # feature, rule, or scenario.  Snapshotting on ``before_all``
             # also lets users call ``context.fixtures.append(...)`` there
             # without first assigning a list.
-            context.fixtures = list(getattr(context, 'fixtures', []))
+            # Use user mode so behave records the attribute as user-owned;
+            # otherwise reassignment in a user hook (``context.fixtures =
+            # [...]``) would emit a ``ContextMaskWarning``.
+            with context.use_with_user_mode():
+                context.fixtures = list(getattr(context, 'fixtures', []))
 
         behave_run_hook(self, hook_name, *args)
 


### PR DESCRIPTION
## Summary

The fixture-scope snapshot added in #179 ran in behave's default BEHAVE mode, which tagged `context.fixtures` as behave-owned. Any later reassignment in a user hook (e.g. `context.fixtures = []` to suppress an inherited fixture) then tripped:

```
ContextMaskWarning: user code is masking context attribute 'fixtures' originally set by behave
```

Fix: wrap the snapshot in `context.use_with_user_mode()` so behave records the attribute as user-owned. Subsequent reassignment by user code is then silent.

## Background — BEHAVE vs USER mode

behave's `Context` tracks an `_origin[attr]` mode for every attribute — set on the *first* assignment — and emits `ContextMaskWarning` when later assignments cross the mode boundary:

- [`ContextMode` enum (BEHAVE / USER)](https://github.com/behave/behave/blob/v1.3.3/behave/runner.py#L59-L66)
- [`Context.use_with_user_mode()`](https://github.com/behave/behave/blob/v1.3.3/behave/runner.py#L365-L367) — context manager that flips `_mode` to USER
- [`Context._emit_warning()`](https://github.com/behave/behave/blob/v1.3.3/behave/runner.py#L392-L406) — the source of the warning; fires when `_mode is USER` and `_origin[attr] is not USER`
- [`Context.__setattr__()`](https://github.com/behave/behave/blob/v1.3.3/behave/runner.py#L432-L456) — locks `_origin[attr]` on first assignment

Our monkey-patched `run_hook` snapshot runs *before* behave's `with ctx.use_with_user_mode():` block around user hooks, so without an explicit user-mode wrapper, the first snapshot assignment recorded `_origin['fixtures'] = BEHAVE`.

## Test plan

- [x] `tox -e py314-django52` acceptance run — `ContextMaskWarning` no longer emitted; 12 features / 32 scenarios pass.
- [x] `tox -e py314-django60` acceptance run — same result.
- [x] Confirmed the warning *was* coming from the "Override inherited fixtures with empty list" scenario (`tests/acceptance/environment.py:40`).